### PR TITLE
feat: scale identification quiz system (v3.4) + bugfixes

### DIFF
--- a/src/components/ChordCard.svelte
+++ b/src/components/ChordCard.svelte
@@ -56,7 +56,7 @@
 	<div class="card-fill" style="width: {cstate.unlocked && cstate.enabled ? accuracy : 0}%"></div>
 	<div class="card-content">
 		<div class="id">
-			{cstate.unlocked ? def.id.toUpperCase() : 'NA'}
+			{cstate.unlocked ? (def.label ?? def.id.toUpperCase()) : 'NA'}
 			{#if masteryDots()}
 				<span class="mastery-dots" style="color: {masteryColor()}">{masteryDots()}</span>
 			{/if}

--- a/src/lib/chords.ts
+++ b/src/lib/chords.ts
@@ -16,7 +16,7 @@ export const CHORDS: ChordDef[] = [
 
 	// Tier 4 — Extended seventh chords
 	{ id: 'dim7', name: 'Diminished 7th', intervals: [0, 3, 6, 9], tier: 4, category: 'seventh' },
-	{ id: 'hdim7', name: 'Half-dim 7th', intervals: [0, 3, 6, 10], tier: 4, category: 'seventh' },
+	{ id: 'hdim7', name: 'Half-dim 7th', label: 'HD7', intervals: [0, 3, 6, 10], tier: 4, category: 'seventh' },
 	{ id: 'aug7', name: 'Augmented 7th', intervals: [0, 4, 8, 10], tier: 4, category: 'seventh' },
 ];
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -96,6 +96,7 @@ export type ChordCategory = 'triad' | 'seventh';
 export interface ChordDef {
 	id: string;            // e.g. "maj", "min", "dim", "aug", "dom7"
 	name: string;          // e.g. "Major", "Minor 7th"
+	label?: string;        // short display label (defaults to id.toUpperCase())
 	intervals: number[];   // semitones from root, e.g. [0, 4, 7]
 	tier: number;          // 1-4 unlock tier (chord-specific)
 	category: ChordCategory;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -333,8 +333,8 @@
 		cursor: pointer;
 		transition: color 0.15s, border-color 0.15s, background 0.15s;
 	}
-	.switch-btn:first-child {
-		margin-right: -1px;
+	.switch-btn + .switch-btn {
+		margin-left: -1px;
 	}
 	.switch-btn.active {
 		color: var(--accent);

--- a/src/routes/progress/+page.svelte
+++ b/src/routes/progress/+page.svelte
@@ -332,7 +332,7 @@
 		cursor: pointer;
 		transition: color 0.15s, border-color 0.15s, background 0.15s;
 	}
-	.ct-btn:first-child { margin-right: -1px; }
+	.ct-btn + .ct-btn { margin-left: -1px; }
 	.ct-btn.active {
 		color: var(--accent);
 		border-color: var(--accent);


### PR DESCRIPTION
## Summary

### Scale Quiz System (v3.4)
- 9 scales across 3 tiers: Major, Natural Minor, Major Pentatonic (T1), Harmonic Minor, Minor Pentatonic (T2), Blues, Whole Tone, Melodic Minor, Chromatic (T3)
- Sequential note playback via new `playScale()` audio function
- Auto A/B comparison on wrong answers (hear correct then wrong)
- SM-2 spaced repetition, tier unlock progression (10q/70%, 30q/70%)
- Scales unlock gate: Bronze mastery on 3+ intervals
- 3-way content switcher: INTERVALS | CHORDS | SCALES
- Short display labels (MAJ, NTm, M5, etc.) for quiz grid + progress cards
- ScaleCard component, /quiz/scales route, progress page integration
- State migration for existing users (preserves interval/chord data)

### Bugfixes
- Fix content switcher border overlap for 3-tab layout (home + progress pages)
- Add optional `label` field to ChordDef — `hdim7` displays as `HD7` (4-char max)
- ChordCard + AnswerGrid use `label ?? id.toUpperCase()` fallback

### Tests
- 71 new tests (188 total), all passing
- Zero regressions

### QA
- Palm QA sign-off on both initial implementation and bugfix commit
- Browser walkthrough: switcher, quiz flow, A/B feedback, progress page, state persistence all verified