### PR TITLE
fix: scale card font size + audio click artifacts

### DIFF
--- a/SHORTHANDS.md
+++ b/SHORTHANDS.md
@@ -1,0 +1,65 @@
+# SHORTHANDS.md — Content ID Reference
+
+Max 4 characters. Used in progress cards, quiz UI, and telemetry.
+
+## Intervals (2 chars)
+| ID | Name | Semitones |
+|----|------|-----------|
+| P1 | Unison | 0 |
+| m2 | Minor 2nd | 1 |
+| M2 | Major 2nd | 2 |
+| m3 | Minor 3rd | 3 |
+| M3 | Major 3rd | 4 |
+| P4 | Perfect 4th | 5 |
+| TT | Tritone | 6 |
+| P5 | Perfect 5th | 7 |
+| m6 | Minor 6th | 8 |
+| M6 | Major 6th | 9 |
+| m7 | Minor 7th | 10 |
+| M7 | Major 7th | 11 |
+| P8 | Octave | 12 |
+
+## Chords (3-4 chars)
+| ID | Name | Intervals |
+|----|------|-----------|
+| maj | Major | 0,4,7 |
+| min | Minor | 0,3,7 |
+| dim | Diminished | 0,3,6 |
+| aug | Augmented | 0,4,8 |
+| dom7 | Dominant 7th | 0,4,7,10 |
+| maj7 | Major 7th | 0,4,7,11 |
+| min7 | Minor 7th | 0,3,7,10 |
+| dim7 | Diminished 7th | 0,3,6,9 |
+| hd7 | Half-dim 7th | 0,3,6,10 |
+| aug7 | Augmented 7th | 0,4,8,10 |
+
+### Future chords
+| ID | Name |
+|----|------|
+| sus2 | Suspended 2nd |
+| sus4 | Suspended 4th |
+| add9 | Added 9th |
+| 6 | Major 6th |
+| m6 | Minor 6th |
+
+## Scales (3-4 chars)
+| ID | Name | Tier |
+|----|------|------|
+| MAJ | Major | 1 |
+| MIN | Natural Minor | 1 |
+| MAJP | Major Pentatonic | 1 |
+| HMIN | Harmonic Minor | 2 |
+| MINP | Minor Pentatonic | 2 |
+| BLU | Blues | 3 |
+| WHL | Whole Tone | 3 |
+| MMIN | Melodic Minor | 3 |
+
+### Future scales (modes — Tier 4, needs drone)
+| ID | Name |
+|----|------|
+| DOR | Dorian |
+| MIX | Mixolydian |
+| PHR | Phrygian |
+| LYD | Lydian |
+| LOC | Locrian |
+| AEO | Aeolian |

--- a/src/components/ScaleCard.svelte
+++ b/src/components/ScaleCard.svelte
@@ -86,11 +86,12 @@
 	.disabled .name { color: var(--text-secondary); }
 	.disabled .toggle { opacity: calc(1 / 0.55); }
 	.id {
-		font-size: 1.1rem; font-weight: 900;
+		font-size: 2rem; font-weight: 900;
 		font-family: 'BPdots', 'JetBrains Mono', monospace; text-align: center;
 		color: var(--accent); line-height: 1;
+		transform: translateY(-5px);
 	}
-	.locked .id { color: var(--hot); font-size: 1.1rem; }
+	.locked .id { color: var(--hot); font-size: 2rem; }
 	.name { font-weight: 400; font-size: 0.85rem; letter-spacing: 0.02em; font-family: var(--font-display); }
 	.stats { font-size: 0.4rem; color: var(--text-secondary); font-weight: 600; font-family: var(--mono); display: flex; align-items: center; gap: 2px; opacity: 0.7; }
 	.stat-tag {

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -548,19 +548,30 @@ export function playScale(
 	const master = getMasterOutput();
 	const now = audioCtx.currentTime;
 
-	const noteDuration = (tempo * 1.5) / 1000; // slight legato overlap
-
-	const playToNode =
-		toneType === 'piano'
-			? playPianoToneToNode
-			: toneType === 'epiano'
-				? playEpianoToneToNode
-				: playSineToneToNode;
+	const noteSpacing = tempo / 1000; // seconds between note onsets
+	// Note duration slightly shorter than spacing to avoid overlap clicks
+	const noteDuration = noteSpacing * 0.85;
+	// Fade-out ramp time at end of each note
+	const fadeOut = 0.03; // 30ms ramp to zero — eliminates clicks
 
 	intervals.forEach((semitones, i) => {
 		const freq = midiToFreq(rootMidi + semitones);
-		const startTime = now + i * (tempo / 1000);
-		playToNode(freq, startTime, noteDuration, audioCtx, master);
+		const startTime = now + i * noteSpacing;
+
+		// Use a per-note gain wrapper with guaranteed clean fade-out
+		const noteGain = audioCtx.createGain();
+		noteGain.gain.setValueAtTime(1, startTime);
+		noteGain.gain.setValueAtTime(1, startTime + noteDuration - fadeOut);
+		noteGain.gain.linearRampToValueAtTime(0, startTime + noteDuration);
+		noteGain.connect(master);
+
+		if (toneType === 'piano') {
+			playPianoToneToNode(freq, startTime, noteDuration, audioCtx, noteGain);
+		} else if (toneType === 'epiano') {
+			playEpianoToneToNode(freq, startTime, noteDuration, audioCtx, noteGain);
+		} else {
+			playSineToneToNode(freq, startTime, noteDuration, audioCtx, noteGain);
+		}
 	});
 }
 


### PR DESCRIPTION
## Fixes

**Bug 1 — Scale progress card font size:**
- ScaleCard `.id` was `1.1rem`, IntervalCard/ChordCard are `2rem`
- Now all three card types use `2rem` with matching `translateY(-5px)` alignment
- Locked state font size also fixed

**Bug 2 — Audio clicks between scale notes:**
- Root cause: note duration was 150% of spacing, creating 75ms overlap where oscillator hard-stops mid-gain-envelope → audible click
- Fix: note duration reduced to 85% of spacing (no overlap), plus a per-note gain wrapper with 30ms linear fade-out ramp to guarantee zero-amplitude before oscillator stops
- Clean silence between notes, no artifacts

**Tests:** 188/188 passing, zero regressions