### PR TITLE
feat: mixed-case labels for chords + scales per SHORTHANDS.md

### DIFF
--- a/SHORTHANDS.md
+++ b/SHORTHANDS.md
@@ -1,6 +1,6 @@
 # SHORTHANDS.md — Content ID Reference
 
-Max 4 characters. Used in progress cards, quiz UI, and telemetry.
+Max 5 characters. Mixed case for readability. Used in progress cards, quiz UI, and telemetry.
 
 ## Intervals (2 chars)
 | ID | Name | Semitones |
@@ -19,47 +19,45 @@ Max 4 characters. Used in progress cards, quiz UI, and telemetry.
 | M7 | Major 7th | 11 |
 | P8 | Octave | 12 |
 
-## Chords (3-4 chars)
+## Chords (3-5 chars)
 | ID | Name | Intervals |
 |----|------|-----------|
-| maj | Major | 0,4,7 |
-| min | Minor | 0,3,7 |
-| dim | Diminished | 0,3,6 |
-| aug | Augmented | 0,4,8 |
-| dom7 | Dominant 7th | 0,4,7,10 |
-| maj7 | Major 7th | 0,4,7,11 |
-| min7 | Minor 7th | 0,3,7,10 |
-| dim7 | Diminished 7th | 0,3,6,9 |
-| hd7 | Half-dim 7th | 0,3,6,10 |
-| aug7 | Augmented 7th | 0,4,8,10 |
+| Maj | Major | 0,4,7 |
+| Min | Minor | 0,3,7 |
+| Dim | Diminished | 0,3,6 |
+| Aug | Augmented | 0,4,8 |
+| Dom7 | Dominant 7th | 0,4,7,10 |
+| Maj7 | Major 7th | 0,4,7,11 |
+| Min7 | Minor 7th | 0,3,7,10 |
+| Dim7 | Diminished 7th | 0,3,6,9 |
+| hDim7 | Half-dim 7th | 0,3,6,10 |
+| Aug7 | Augmented 7th | 0,4,8,10 |
 
 ### Future chords
 | ID | Name |
 |----|------|
-| sus2 | Suspended 2nd |
-| sus4 | Suspended 4th |
-| add9 | Added 9th |
-| 6 | Major 6th |
-| m6 | Minor 6th |
+| Sus2 | Suspended 2nd |
+| Sus4 | Suspended 4th |
+| Add9 | Added 9th |
 
 ## Scales (3-4 chars)
 | ID | Name | Tier |
 |----|------|------|
-| MAJ | Major | 1 |
-| MIN | Natural Minor | 1 |
-| MAJP | Major Pentatonic | 1 |
-| HMIN | Harmonic Minor | 2 |
-| MINP | Minor Pentatonic | 2 |
-| BLU | Blues | 3 |
-| WHL | Whole Tone | 3 |
-| MMIN | Melodic Minor | 3 |
+| Maj | Major | 1 |
+| Min | Natural Minor | 1 |
+| MajP | Major Pentatonic | 1 |
+| hMin | Harmonic Minor | 2 |
+| MinP | Minor Pentatonic | 2 |
+| Blu | Blues | 3 |
+| Whol | Whole Tone | 3 |
+| mMin | Melodic Minor | 3 |
 
 ### Future scales (modes — Tier 4, needs drone)
 | ID | Name |
 |----|------|
-| DOR | Dorian |
-| MIX | Mixolydian |
-| PHR | Phrygian |
-| LYD | Lydian |
-| LOC | Locrian |
-| AEO | Aeolian |
+| Dor | Dorian |
+| Mix | Mixolydian |
+| Phr | Phrygian |
+| Lyd | Lydian |
+| Loc | Locrian |
+| Aeo | Aeolian |

--- a/src/components/ChordCard.svelte
+++ b/src/components/ChordCard.svelte
@@ -101,7 +101,7 @@
 	}
 	.card-content {
 		position: relative; z-index: 1;
-		display: grid; grid-template-columns: 3.5rem 1fr auto;
+		display: grid; grid-template-columns: 5.5rem 1fr auto;
 		align-items: center; gap: 0.75rem; padding: 0.85rem;
 	}
 	.locked { opacity: 0.4; border-left-color: var(--hot); }

--- a/src/components/IntervalCard.svelte
+++ b/src/components/IntervalCard.svelte
@@ -103,7 +103,7 @@
 	}
 	.card-content {
 		position: relative; z-index: 1;
-		display: grid; grid-template-columns: 3.5rem 1fr auto;
+		display: grid; grid-template-columns: 5.5rem 1fr auto;
 		align-items: center; gap: 0.75rem; padding: 0.85rem;
 	}
 	.locked { opacity: 0.4; border-left-color: var(--hot); }

--- a/src/components/ScaleCard.svelte
+++ b/src/components/ScaleCard.svelte
@@ -77,7 +77,7 @@
 	}
 	.card-content {
 		position: relative; z-index: 1;
-		display: grid; grid-template-columns: 3.5rem 1fr auto;
+		display: grid; grid-template-columns: 5.5rem 1fr auto;
 		align-items: center; gap: 0.75rem; padding: 0.85rem;
 	}
 	.locked { opacity: 0.4; border-left-color: var(--hot); }

--- a/src/lib/chords.ts
+++ b/src/lib/chords.ts
@@ -2,22 +2,22 @@ import type { ChordDef, ChordState } from './types';
 
 export const CHORDS: ChordDef[] = [
 	// Tier 1 — Triads (unlocked when chord system is discovered)
-	{ id: 'maj', name: 'Major', intervals: [0, 4, 7], tier: 1, category: 'triad' },
-	{ id: 'min', name: 'Minor', intervals: [0, 3, 7], tier: 1, category: 'triad' },
+	{ id: 'maj', name: 'Major', label: 'Maj', intervals: [0, 4, 7], tier: 1, category: 'triad' },
+	{ id: 'min', name: 'Minor', label: 'Min', intervals: [0, 3, 7], tier: 1, category: 'triad' },
 
 	// Tier 2 — Altered triads
-	{ id: 'dim', name: 'Diminished', intervals: [0, 3, 6], tier: 2, category: 'triad' },
-	{ id: 'aug', name: 'Augmented', intervals: [0, 4, 8], tier: 2, category: 'triad' },
+	{ id: 'dim', name: 'Diminished', label: 'Dim', intervals: [0, 3, 6], tier: 2, category: 'triad' },
+	{ id: 'aug', name: 'Augmented', label: 'Aug', intervals: [0, 4, 8], tier: 2, category: 'triad' },
 
 	// Tier 3 — Seventh chords
-	{ id: 'dom7', name: 'Dominant 7th', intervals: [0, 4, 7, 10], tier: 3, category: 'seventh' },
-	{ id: 'maj7', name: 'Major 7th', intervals: [0, 4, 7, 11], tier: 3, category: 'seventh' },
-	{ id: 'min7', name: 'Minor 7th', intervals: [0, 3, 7, 10], tier: 3, category: 'seventh' },
+	{ id: 'dom7', name: 'Dominant 7th', label: 'Dom7', intervals: [0, 4, 7, 10], tier: 3, category: 'seventh' },
+	{ id: 'maj7', name: 'Major 7th', label: 'Maj7', intervals: [0, 4, 7, 11], tier: 3, category: 'seventh' },
+	{ id: 'min7', name: 'Minor 7th', label: 'Min7', intervals: [0, 3, 7, 10], tier: 3, category: 'seventh' },
 
 	// Tier 4 — Extended seventh chords
-	{ id: 'dim7', name: 'Diminished 7th', intervals: [0, 3, 6, 9], tier: 4, category: 'seventh' },
-	{ id: 'hdim7', name: 'Half-dim 7th', label: 'HD7', intervals: [0, 3, 6, 10], tier: 4, category: 'seventh' },
-	{ id: 'aug7', name: 'Augmented 7th', intervals: [0, 4, 8, 10], tier: 4, category: 'seventh' },
+	{ id: 'dim7', name: 'Diminished 7th', label: 'Dim7', intervals: [0, 3, 6, 9], tier: 4, category: 'seventh' },
+	{ id: 'hdim7', name: 'Half-dim 7th', label: 'hDim7', intervals: [0, 3, 6, 10], tier: 4, category: 'seventh' },
+	{ id: 'aug7', name: 'Augmented 7th', label: 'Aug7', intervals: [0, 4, 8, 10], tier: 4, category: 'seventh' },
 ];
 
 export function getChordsByTier(tier: number): ChordDef[] {

--- a/src/lib/scales.ts
+++ b/src/lib/scales.ts
@@ -2,19 +2,19 @@ import type { ScaleDef, ScaleState } from './types';
 
 export const SCALES: ScaleDef[] = [
 	// Tier 1 — Big Three
-	{ id: 'major', name: 'Major', label: 'MAJ', intervals: [0, 2, 4, 5, 7, 9, 11, 12], tier: 1, category: 'diatonic' },
-	{ id: 'nat_min', name: 'Natural Minor', label: 'NTm', intervals: [0, 2, 3, 5, 7, 8, 10, 12], tier: 1, category: 'diatonic' },
-	{ id: 'maj_pent', name: 'Major Pentatonic', label: 'M5', intervals: [0, 2, 4, 7, 9, 12], tier: 1, category: 'pentatonic' },
+	{ id: 'major', name: 'Major', label: 'Maj', intervals: [0, 2, 4, 5, 7, 9, 11, 12], tier: 1, category: 'diatonic' },
+	{ id: 'nat_min', name: 'Natural Minor', label: 'Min', intervals: [0, 2, 3, 5, 7, 8, 10, 12], tier: 1, category: 'diatonic' },
+	{ id: 'maj_pent', name: 'Major Pentatonic', label: 'MajP', intervals: [0, 2, 4, 7, 9, 12], tier: 1, category: 'pentatonic' },
 
 	// Tier 2
-	{ id: 'harm_min', name: 'Harmonic Minor', label: 'HRm', intervals: [0, 2, 3, 5, 7, 8, 11, 12], tier: 2, category: 'diatonic' },
-	{ id: 'min_pent', name: 'Minor Pentatonic', label: 'm5', intervals: [0, 3, 5, 7, 10, 12], tier: 2, category: 'pentatonic' },
+	{ id: 'harm_min', name: 'Harmonic Minor', label: 'hMin', intervals: [0, 2, 3, 5, 7, 8, 11, 12], tier: 2, category: 'diatonic' },
+	{ id: 'min_pent', name: 'Minor Pentatonic', label: 'MinP', intervals: [0, 3, 5, 7, 10, 12], tier: 2, category: 'pentatonic' },
 
 	// Tier 3
-	{ id: 'blues', name: 'Blues', label: 'BLU', intervals: [0, 3, 5, 6, 7, 10, 12], tier: 3, category: 'pentatonic' },
-	{ id: 'whole', name: 'Whole Tone', label: 'WHL', intervals: [0, 2, 4, 6, 8, 10, 12], tier: 3, category: 'symmetric' },
-	{ id: 'mel_min', name: 'Melodic Minor', label: 'MLm', intervals: [0, 2, 3, 5, 7, 9, 11, 12], tier: 3, category: 'diatonic' },
-	{ id: 'chromatic', name: 'Chromatic', label: 'CHR', intervals: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], tier: 3, category: 'symmetric' },
+	{ id: 'blues', name: 'Blues', label: 'Blu', intervals: [0, 3, 5, 6, 7, 10, 12], tier: 3, category: 'pentatonic' },
+	{ id: 'whole', name: 'Whole Tone', label: 'Whol', intervals: [0, 2, 4, 6, 8, 10, 12], tier: 3, category: 'symmetric' },
+	{ id: 'mel_min', name: 'Melodic Minor', label: 'mMin', intervals: [0, 2, 3, 5, 7, 9, 11, 12], tier: 3, category: 'diatonic' },
+	{ id: 'chromatic', name: 'Chromatic', label: 'Chr', intervals: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], tier: 3, category: 'symmetric' },
 ];
 
 export function getScalesByTier(tier: number): ScaleDef[] {

--- a/src/routes/quiz/+page.svelte
+++ b/src/routes/quiz/+page.svelte
@@ -525,7 +525,7 @@
 	}
 	.missed-card-content {
 		position: relative; z-index: 1;
-		display: grid; grid-template-columns: 3rem 1fr auto;
+		display: grid; grid-template-columns: 4rem 1fr auto;
 		align-items: center; gap: 0.75rem; padding: 0.7rem 0.85rem;
 	}
 	.missed-id {

--- a/src/routes/quiz/chords/+page.svelte
+++ b/src/routes/quiz/chords/+page.svelte
@@ -306,7 +306,7 @@
 				<button class="missed-card" class:replaying={replayingIndex === i} onclick={() => replayMissed(r)}>
 					<div class="missed-card-fill" style="width: 0%"></div>
 					<div class="missed-card-content">
-						<span class="missed-id">{r.chord.id.toUpperCase()}</span>
+						<span class="missed-id">{r.chord.label ?? r.chord.id.toUpperCase()}</span>
 						<div class="missed-info">
 							<span class="missed-name">{r.chord.name}</span>
 							<span class="missed-detail">answered {r.selectedId}</span>
@@ -550,7 +550,7 @@
 	}
 	.missed-card-content {
 		position: relative; z-index: 1;
-		display: grid; grid-template-columns: 3rem 1fr auto;
+		display: grid; grid-template-columns: 4rem 1fr auto;
 		align-items: center; gap: 0.75rem; padding: 0.7rem 0.85rem;
 	}
 	.missed-id {

--- a/src/routes/quiz/scales/+page.svelte
+++ b/src/routes/quiz/scales/+page.svelte
@@ -503,7 +503,7 @@
 	}
 	.missed-card-content {
 		position: relative; z-index: 1;
-		display: grid; grid-template-columns: 3rem 1fr;
+		display: grid; grid-template-columns: 4rem 1fr;
 		align-items: center; gap: 0.75rem; padding: 0.7rem 0.85rem;
 	}
 	.missed-id {


### PR DESCRIPTION
## Summary

Update all chord and scale display labels to mixed case per SHORTHANDS.md, with 5-char max.

### Changes
- **Chord labels:** Maj, Min, Dim, Aug, Dom7, Maj7, Min7, Dim7, hDim7, Aug7
- **Scale labels:** Maj, Min, MajP, hMin, MinP, Blu, Whol, mMin, Chr
- **ID column width:** 3.5rem → 5.5rem on all progress cards (IntervalCard, ChordCard, ScaleCard) to fit 5-char labels like `hDim7`
- **Missed-card column:** 3rem → 4rem on all quiz summary pages
- **Chord quiz summary:** uses `label ?? id.toUpperCase()` fallback for missed cards
- BPdots renders mixed case correctly — verified in browser

### QA
- 188/188 tests passing
- Palm verified `hDim7` no longer bleeds into name column at 5.5rem
- All label mappings verified against SHORTHANDS.md