### PR TITLE
feat: chord + scale visualization system

### DIFF
--- a/src/components/ChladniCanvas.svelte
+++ b/src/components/ChladniCanvas.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	// Props — frequency ratio from parent
+	let { freqA = 3, freqB = 2 }: { freqA?: number; freqB?: number } = $props();
+
+	let canvas: HTMLCanvasElement;
+	let animId: number;
+
+	const PARTICLE_COUNT = 3000;
+	const SETTLE_SPEED = 0.004;    // how fast particles drift to nodal lines
+	const JITTER = 0.001;          // random noise to keep things alive
+
+	// Chladni equation: cos(n*x)*cos(m*y) - cos(m*x)*cos(n*y)
+	// Nodal lines are where this equals zero
+	function chladni(x: number, y: number, n: number, m: number): number {
+		return Math.cos(n * x) * Math.cos(m * y) - Math.cos(m * x) * Math.cos(n * y);
+	}
+
+	// Gradient of the Chladni function (for particle drift)
+	function chladniGrad(x: number, y: number, n: number, m: number): [number, number] {
+		const h = 0.01;
+		const dx = (chladni(x + h, y, n, m) - chladni(x - h, y, n, m)) / (2 * h);
+		const dy = (chladni(x, y + h, n, m) - chladni(x, y - h, n, m)) / (2 * h);
+		return [dx, dy];
+	}
+
+	let particles: { x: number; y: number }[] = [];
+	let currentN = $state(3);
+	let currentM = $state(2);
+
+	function initParticles() {
+		particles = [];
+		for (let i = 0; i < PARTICLE_COUNT; i++) {
+			particles.push({
+				x: Math.random() * Math.PI * 2,
+				y: Math.random() * Math.PI * 2,
+			});
+		}
+	}
+
+	// React to prop changes — sync to local state for draw loop
+	$effect(() => {
+		const n = freqA;
+		const m = freqB;
+		currentN = n;
+		currentM = m;
+		initParticles();
+		if (canvas) {
+			const ctx = canvas.getContext('2d');
+			if (ctx) {
+				ctx.fillStyle = '#000000';
+				ctx.fillRect(0, 0, canvas.width, canvas.height);
+			}
+		}
+	});
+
+	onMount(() => {
+		const ctx = canvas.getContext('2d')!;
+		const dpr = window.devicePixelRatio || 1;
+
+		function resize() {
+			const rect = canvas.getBoundingClientRect();
+			canvas.width = rect.width * dpr;
+			canvas.height = rect.height * dpr;
+			ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+		}
+
+		resize();
+		window.addEventListener('resize', resize);
+		initParticles();
+
+		function draw() {
+			const w = canvas.width / dpr;
+			const h = canvas.height / dpr;
+			const n = currentN;
+			const m = currentM;
+
+			// Soft fade — particles leave faint trails
+			ctx.fillStyle = 'rgba(0, 0, 0, 0.15)';
+			ctx.fillRect(0, 0, w, h);
+
+			// Update + draw particles
+			ctx.fillStyle = '#C2FE0C';
+			ctx.shadowColor = '#C2FE0C';
+			ctx.shadowBlur = 2;
+
+			for (const p of particles) {
+				// Compute gradient and drift toward nodal line
+				const [gx, gy] = chladniGrad(p.x, p.y, n, m);
+				const val = chladni(p.x, p.y, n, m);
+
+				// Move against gradient (toward zero) proportional to value
+				p.x -= gx * val * SETTLE_SPEED;
+				p.y -= gy * val * SETTLE_SPEED;
+
+				// Add tiny jitter to prevent dead stops
+				p.x += (Math.random() - 0.5) * JITTER;
+				p.y += (Math.random() - 0.5) * JITTER;
+
+				// Wrap around
+				const TAU = Math.PI * 2;
+				if (p.x < 0) p.x += TAU;
+				if (p.x > TAU) p.x -= TAU;
+				if (p.y < 0) p.y += TAU;
+				if (p.y > TAU) p.y -= TAU;
+
+				// Map to screen
+				const sx = (p.x / TAU) * w;
+				const sy = (p.y / TAU) * h;
+
+				// Distance from nodal line = brightness
+				const dist = Math.abs(val);
+				const alpha = Math.max(0.1, 1 - dist * 2);
+
+				ctx.globalAlpha = alpha;
+				ctx.fillRect(sx, sy, 1.2, 1.2);
+			}
+
+			ctx.globalAlpha = 1;
+			ctx.shadowBlur = 0;
+
+			animId = requestAnimationFrame(draw);
+		}
+
+		ctx.fillStyle = '#000000';
+		ctx.fillRect(0, 0, canvas.width, canvas.height);
+		draw();
+
+		return () => {
+			cancelAnimationFrame(animId);
+			window.removeEventListener('resize', resize);
+		};
+	});
+</script>
+
+<div class="chladni-frame">
+	<canvas bind:this={canvas}></canvas>
+	<div class="frame-corner tl"></div>
+	<div class="frame-corner tr"></div>
+	<div class="frame-corner bl"></div>
+	<div class="frame-corner br"></div>
+</div>
+
+<style>
+	.chladni-frame {
+		position: relative;
+		width: 100%;
+		aspect-ratio: 1;
+		border: 1px solid var(--border-heavy);
+		background: #000;
+	}
+
+	canvas {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+
+	.frame-corner {
+		position: absolute;
+		width: 12px;
+		height: 12px;
+		border-color: var(--hot);
+		border-style: solid;
+		opacity: 0.4;
+	}
+	.frame-corner.tl { top: -1px; left: -1px; border-width: 2px 0 0 2px; }
+	.frame-corner.tr { top: -1px; right: -1px; border-width: 2px 2px 0 0; }
+	.frame-corner.bl { bottom: -1px; left: -1px; border-width: 0 0 2px 2px; }
+	.frame-corner.br { bottom: -1px; right: -1px; border-width: 0 2px 2px 0; }
+</style>

--- a/src/components/QuizViz.svelte
+++ b/src/components/QuizViz.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { getRatio, chladni, chladniGrad } from '$lib/viz';
+	import { getAnalyser, getAmplitude } from '$lib/audio';
+
+	interface Props {
+		intervalId?: string;
+		playing?: boolean;
+		size?: number;
+	}
+	let { intervalId = 'P5', playing = false, size = 200 }: Props = $props();
+
+	let canvas: HTMLCanvasElement;
+	let animId: number;
+	let phase = 0;
+
+	// Audio analyser — initialized on first play
+	let analyserRef: AnalyserNode | null = null;
+	let dataArrayRef: Uint8Array | null = null;
+
+	// Chladni particles
+	const PARTICLE_COUNT = 800;
+	const SETTLE_SPEED_BASE = 0.004;
+	const SETTLE_SPEED_BOOST = 0.025;
+	let particles: { x: number; y: number }[] = [];
+	let settleSpeed = SETTLE_SPEED_BASE;
+	let migrateTimer = 0;
+
+	// Track current ratio for draw loop
+	let currentFx = $state(getRatio('P5')[0]);
+	let currentFy = $state(getRatio('P5')[1]);
+
+	function initParticles() {
+		particles = [];
+		const TAU = Math.PI * 2;
+		for (let i = 0; i < PARTICLE_COUNT; i++) {
+			particles.push({ x: Math.random() * TAU, y: Math.random() * TAU });
+		}
+	}
+
+	// React to interval changes
+	$effect(() => {
+		const [fx, fy] = getRatio(intervalId);
+		currentFx = fx;
+		currentFy = fy;
+		settleSpeed = SETTLE_SPEED_BOOST;
+		migrateTimer = 90;
+		if (particles.length === 0) initParticles();
+	});
+
+	// Init analyser when playing starts
+	$effect(() => {
+		if (playing && !analyserRef) {
+			try {
+				const { analyser, dataArray } = getAnalyser();
+				analyserRef = analyser;
+				dataArrayRef = dataArray;
+			} catch { /* audio not ready yet */ }
+		}
+	});
+
+	onMount(() => {
+		const ctx = canvas.getContext('2d')!;
+		const dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+		canvas.width = size * dpr;
+		canvas.height = size * dpr;
+		ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+		initParticles();
+
+		const PHASE_DELTA = Math.PI / 2;
+		const LOOP_POINTS = 300;
+		const BASE_SPEED = 0.003;
+
+		function draw() {
+			const w = size;
+			const h = size;
+			const cx = w / 2;
+			const cy = h / 2;
+			const radius = Math.min(cx, cy) * 0.75;
+			const fx = currentFx;
+			const fy = currentFy;
+
+			// Audio amplitude
+			let amp = 0;
+			if (analyserRef && dataArrayRef) {
+				amp = Math.min(1, getAmplitude(analyserRef, dataArrayRef) * 3);
+			}
+			const radiusPulse = 1 + amp * 0.1;
+			const glowBoost = amp * 8;
+			const rx = radius * radiusPulse;
+			const ry = radius * radiusPulse;
+
+			// Speed scaled by ratio complexity
+			const speed = BASE_SPEED / Math.max(fx, fy);
+
+			// Clear
+			ctx.fillStyle = 'rgba(0, 0, 0, 0.12)';
+			ctx.fillRect(0, 0, w, h);
+
+			// Migration decay
+			if (migrateTimer > 0) {
+				migrateTimer--;
+				if (migrateTimer < 20) {
+					settleSpeed = SETTLE_SPEED_BASE + (SETTLE_SPEED_BOOST - SETTLE_SPEED_BASE) * (migrateTimer / 20);
+				}
+				if (migrateTimer === 0) settleSpeed = SETTLE_SPEED_BASE;
+			}
+
+			// --- Chladni particles ---
+			const TAU = Math.PI * 2;
+			const migrateIntensity = migrateTimer > 20 ? 1 : migrateTimer / 20;
+			for (const p of particles) {
+				const val = chladni(p.x, p.y, fx, fy);
+				const [gx, gy] = chladniGrad(p.x, p.y, fx, fy);
+				p.x -= gx * val * settleSpeed;
+				p.y -= gy * val * settleSpeed;
+				p.x += (Math.random() - 0.5) * 0.002;
+				p.y += (Math.random() - 0.5) * 0.002;
+				if (p.x < 0) p.x += TAU;
+				if (p.x > TAU) p.x -= TAU;
+				if (p.y < 0) p.y += TAU;
+				if (p.y > TAU) p.y -= TAU;
+
+				const sx = (p.x / TAU) * w;
+				const sy = (p.y / TAU) * h;
+				const dist = Math.abs(val);
+				const alpha = Math.min(1, Math.max(0.05, 0.5 - dist * 2) + migrateIntensity * 0.2);
+				ctx.globalAlpha = alpha;
+				ctx.fillStyle = migrateIntensity > 0.1 ? '#5A4CFF' : '#3A2CFF';
+				ctx.fillRect(sx, sy, 1, 1);
+			}
+			ctx.globalAlpha = 1;
+
+			// --- 4-way mirrored Lissajous ---
+			// Compute points once
+			const pts: { x: number; y: number }[] = [];
+			const sweepEnd = Math.PI * 2;
+			for (let i = 0; i <= LOOP_POINTS; i++) {
+				const t = (i / LOOP_POINTS) * sweepEnd;
+				pts.push({
+					x: rx * Math.sin(fx * t + PHASE_DELTA),
+					y: ry * Math.sin(fy * t),
+				});
+			}
+
+			// Draw 4 mirrors via canvas transform
+			ctx.strokeStyle = '#C2FE0C';
+			ctx.lineWidth = 1;
+			ctx.shadowColor = '#C2FE0C';
+			ctx.shadowBlur = 3 + glowBoost;
+			ctx.globalAlpha = 0.8;
+
+			const mirrors = [
+				[1, 1], [-1, 1], [1, -1], [-1, -1]
+			];
+
+			for (const [sx, sy] of mirrors) {
+				ctx.save();
+				ctx.translate(cx, cy);
+				ctx.scale(sx, sy);
+				ctx.rotate(phase);
+				ctx.beginPath();
+				for (let i = 0; i < pts.length; i++) {
+					if (i === 0) ctx.moveTo(pts[i].x, pts[i].y);
+					else ctx.lineTo(pts[i].x, pts[i].y);
+				}
+				ctx.closePath();
+				ctx.stroke();
+				ctx.restore();
+			}
+
+			ctx.globalAlpha = 1;
+			ctx.shadowBlur = 0;
+
+			// --- Vignette ---
+			const vig = ctx.createRadialGradient(cx, cy, radius * 0.4, cx, cy, radius * 1.1);
+			vig.addColorStop(0, 'rgba(0,0,0,0)');
+			vig.addColorStop(1, 'rgba(0,0,0,0.5)');
+			ctx.fillStyle = vig;
+			ctx.fillRect(0, 0, w, h);
+
+			phase += speed;
+			animId = requestAnimationFrame(draw);
+		}
+
+		ctx.fillStyle = '#000';
+		ctx.fillRect(0, 0, canvas.width, canvas.height);
+		draw();
+
+		return () => cancelAnimationFrame(animId);
+	});
+</script>
+
+<canvas
+	bind:this={canvas}
+	class="quiz-viz"
+	style="width: {size}px; height: {size}px;"
+></canvas>
+
+<style>
+	.quiz-viz {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		border-radius: 50%;
+		z-index: 0;
+		pointer-events: none;
+	}
+</style>

--- a/src/lib/viz.ts
+++ b/src/lib/viz.ts
@@ -35,3 +35,136 @@ export function chladniGrad(x: number, y: number, n: number, m: number): [number
 	const dy = (chladni(x, y + h, n, m) - chladni(x, y - h, n, m)) / (2 * h);
 	return [dx, dy];
 }
+
+// ── Superposition Chladni (multi-mode for chords) ──────────────────
+
+/** A single Chladni mode with optional amplitude weight */
+export interface ChladniMode {
+	n: number;
+	m: number;
+	amp: number;  // amplitude weight (default 1)
+}
+
+/**
+ * Superposition of multiple Chladni modes.
+ * Returns combined displacement — nodal lines are where this ≈ 0.
+ */
+export function chladniSuper(x: number, y: number, modes: ChladniMode[]): number {
+	let sum = 0;
+	for (const { n, m, amp } of modes) {
+		sum += amp * (Math.cos(n * x) * Math.cos(m * y) - Math.cos(m * x) * Math.cos(n * y));
+	}
+	return sum;
+}
+
+/**
+ * Gradient of superposed Chladni field (for particle drift toward combined nodal lines).
+ */
+export function chladniGradSuper(x: number, y: number, modes: ChladniMode[]): [number, number] {
+	const h = 0.01;
+	const dx = (chladniSuper(x + h, y, modes) - chladniSuper(x - h, y, modes)) / (2 * h);
+	const dy = (chladniSuper(x, y + h, modes) - chladniSuper(x, y - h, modes)) / (2 * h);
+	return [dx, dy];
+}
+
+/**
+ * Map a MIDI note to a Chladni plate mode (n, m).
+ * Lower notes → simpler modes, higher → more complex.
+ * Returns [n, m] where n < m (avoids degenerate n=m case).
+ */
+export function midiToChladniMode(midi: number): [number, number] {
+	const note = midi % 12;
+	const modes: [number, number][] = [
+		[1, 2], [2, 3], [1, 3], [3, 4], [2, 4], [1, 4],
+		[3, 5], [2, 5], [4, 5], [3, 6], [2, 6], [5, 6],
+	];
+	return modes[note];
+}
+
+/**
+ * Convert chord intervals (semitones from root) to ChladniMode[] for superposition.
+ * Each chord tone maps to a plate mode via midiToChladniMode.
+ * Amplitude is equal for all tones (can be weighted later).
+ */
+export function chordToModes(rootMidi: number, intervals: number[]): ChladniMode[] {
+	return intervals.map((semitones) => {
+		const [n, m] = midiToChladniMode(rootMidi + semitones);
+		return { n, m, amp: 1 };
+	});
+}
+
+// ── 3D Harmonograph (multi-frequency Lissajous for chords) ─────────
+
+/** Just-intonation ratio for a semitone offset from root */
+const JI_RATIOS: Record<number, number> = {
+	0: 1,        // unison
+	1: 16 / 15,  // m2
+	2: 9 / 8,    // M2
+	3: 6 / 5,    // m3
+	4: 5 / 4,    // M3
+	5: 4 / 3,    // P4
+	6: 7 / 5,    // TT
+	7: 3 / 2,    // P5
+	8: 8 / 5,    // m6
+	9: 5 / 3,    // M6
+	10: 9 / 5,   // m7
+	11: 15 / 8,  // M7
+	12: 2,       // P8
+};
+
+/** Get just-intonation frequency ratio for a semitone offset */
+export function jiRatio(semitones: number): number {
+	return JI_RATIOS[semitones % 12] ?? 1;
+}
+
+/**
+ * Compute a 3D harmonograph point for a chord.
+ * Each note contributes one axis (or is distributed across axes for >3 notes).
+ *
+ * For triads (3 notes):  x = sin(f1*t), y = sin(f2*t), z = sin(f3*t)
+ * For tetrads (4 notes): x = sin(f1*t) + 0.3*sin(f4*t), y = sin(f2*t), z = sin(f3*t)
+ *   (4th note modulates the X axis — Moto's "root triad + extension" idea)
+ *
+ * Returns [x, y] after 3D→2D isometric projection.
+ */
+export function harmonograph3D(
+	t: number,
+	intervals: number[],
+	radius: number,
+	phaseOffset: number = Math.PI / 4,
+	rotAngle: number = 0,
+): [number, number] {
+	const freqs = intervals.map((s) => jiRatio(s));
+
+	let x: number, y: number, z: number;
+
+	if (freqs.length <= 2) {
+		// Fallback: standard 2D Lissajous
+		x = Math.sin(freqs[0] * t + phaseOffset);
+		y = Math.sin((freqs[1] ?? freqs[0]) * t);
+		z = 0;
+	} else if (freqs.length === 3) {
+		// Triad: one frequency per axis
+		x = Math.sin(freqs[0] * t + phaseOffset);
+		y = Math.sin(freqs[1] * t);
+		z = Math.sin(freqs[2] * t + phaseOffset * 0.5);
+	} else {
+		// Tetrad+: root triad on axes, extensions modulate X
+		x = Math.sin(freqs[0] * t + phaseOffset);
+		y = Math.sin(freqs[1] * t);
+		z = Math.sin(freqs[2] * t + phaseOffset * 0.5);
+		// Additional notes modulate with decreasing weight
+		for (let i = 3; i < freqs.length; i++) {
+			const weight = 0.3 / (i - 2);
+			x += weight * Math.sin(freqs[i] * t + phaseOffset * (i * 0.3));
+		}
+	}
+
+	// 3D → 2D isometric projection with rotation
+	const cosR = Math.cos(rotAngle);
+	const sinR = Math.sin(rotAngle);
+	const px = (x * cosR - z * sinR) * radius;
+	const py = (y * 0.85 + (x * sinR + z * cosR) * 0.35) * radius;
+
+	return [px, py];
+}

--- a/src/routes/lab/+page.svelte
+++ b/src/routes/lab/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { base } from '$app/paths';
 	import { INTERVALS } from '$lib/intervals';
 	import { playInterval, getAnalyser, getAmplitude } from '$lib/audio';
 	import { loadState } from '$lib/state';
@@ -448,6 +449,11 @@
 			<span class="hud-tag">LAB</span>
 			<h1>VISUALIZATION</h1>
 		</div>
+		<nav class="lab-nav">
+			<a href="{base}/lab" class="lab-nav-link active" aria-label="Intervals">INT</a>
+			<a href="{base}/lab/chords" class="lab-nav-link" aria-label="Chords">CHRD</a>
+			<a href="{base}/lab/scales" class="lab-nav-link" aria-label="Scales">SCALE</a>
+		</nav>
 	</header>
 
 	<div class="canvas-frame">
@@ -498,6 +504,33 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+	}
+
+	.lab-nav {
+		display: flex;
+		gap: 0.25rem;
+	}
+
+	.lab-nav-link {
+		font-family: var(--mono);
+		font-size: 0.6rem;
+		letter-spacing: 0.08em;
+		padding: 0.2rem 0.4rem;
+		border: 1px solid var(--border-heavy);
+		color: var(--text-secondary);
+		text-decoration: none;
+		transition: all 0.15s ease;
+	}
+
+	.lab-nav-link:hover {
+		border-color: var(--accent);
+		color: var(--text-primary);
+	}
+
+	.lab-nav-link.active {
+		border-color: var(--accent);
+		color: var(--accent);
+		background: var(--accent-dim);
 	}
 
 	.lab-title {

--- a/src/routes/lab/chords/+page.svelte
+++ b/src/routes/lab/chords/+page.svelte
@@ -1,0 +1,594 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { base } from '$app/paths';
+	import { CHORDS } from '$lib/chords';
+	import { chladniSuper, chladniGradSuper, chordToModes, harmonograph3D } from '$lib/viz';
+	import type { ChladniMode } from '$lib/viz';
+	import { playChord } from '$lib/audio';
+	import { getAnalyser, getAmplitude } from '$lib/audio';
+
+	// ── State ──
+	let selected = $state('maj');
+	let showChladni = $state(true);
+	let showHarmonograph = $state(true);
+	let isPlaying = $state(false);
+
+	const ROOT_MIDI = 60; // C4
+
+	let chord = $derived(CHORDS.find(c => c.id === selected)!);
+	let modes = $derived(chordToModes(ROOT_MIDI, chord.intervals));
+
+	// ── Canvas refs ──
+	let mainCanvas: HTMLCanvasElement;
+	let animId: number;
+
+	// ── Chladni particles ──
+	const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
+	const PARTICLE_COUNT = isMobile ? 1500 : 3500;
+	const SETTLE_SPEED_BASE = 0.003;
+	const SETTLE_SPEED_BOOST = 0.02;
+	const JITTER = 0.001;
+	const SHAKE_BASE = 0.015;
+	const SHAKE_AUDIO = 0.05;
+	let particles: { x: number; y: number }[] = [];
+	let settleSpeed = SETTLE_SPEED_BASE;
+	let migrateTimer = 0;
+
+	// ── Harmonograph state ──
+	let hPhase = Math.PI * 4;  // start with some history so trail is visible immediately
+	const H_TRAIL = 500;
+	const H_SPEED_BASE = 0.004;
+	let rotAngle = 0;
+
+	// ── Audio reactive ──
+	let analyserRef: AnalyserNode | null = null;
+	let dataArrayRef: Uint8Array | null = null;
+	let amplitude = 0;
+
+	// ── Layer opacity (smooth transitions) ──
+	let chladniOpacity = 1;
+	let harmonographOpacity = 1;
+
+	// ── Current modes for draw loop (avoid reactivity overhead in hot path) ──
+	let currentModes: ChladniMode[] = chordToModes(ROOT_MIDI, CHORDS[0].intervals);
+	let currentIntervals: number[] = CHORDS[0].intervals;
+
+	function initParticles() {
+		particles = [];
+		const TAU = Math.PI * 2;
+		for (let i = 0; i < PARTICLE_COUNT; i++) {
+			particles.push({ x: Math.random() * TAU, y: Math.random() * TAU });
+		}
+	}
+
+	function handlePlay() {
+		if (!analyserRef) {
+			const { analyser, dataArray } = getAnalyser();
+			analyserRef = analyser;
+			dataArrayRef = dataArray;
+		}
+		isPlaying = true;
+		playChord(ROOT_MIDI, chord.intervals, 'root', 'epiano', false);
+		settleSpeed = SETTLE_SPEED_BOOST;
+		migrateTimer = 120;
+		setTimeout(() => { isPlaying = false; }, 2000);
+	}
+
+	// React to chord changes
+	let firstRun = true;
+	$effect(() => {
+		currentModes = chordToModes(ROOT_MIDI, chord.intervals);
+		currentIntervals = chord.intervals;
+		settleSpeed = SETTLE_SPEED_BOOST;
+		migrateTimer = 120;
+		if (particles.length === 0) initParticles();
+		if (!firstRun) {
+			handlePlay();
+		}
+		firstRun = false;
+	});
+
+	// ── Noise texture ──
+	let noiseCanvas: HTMLCanvasElement | null = null;
+	let noiseCtx: CanvasRenderingContext2D | null = null;
+
+	function generateNoise(w: number, h: number) {
+		if (!noiseCanvas) {
+			noiseCanvas = document.createElement('canvas');
+			noiseCtx = noiseCanvas.getContext('2d')!;
+		}
+		noiseCanvas.width = w;
+		noiseCanvas.height = h;
+	}
+
+	function refreshNoise(w: number, h: number) {
+		if (!noiseCtx || !noiseCanvas) return;
+		const imgData = noiseCtx.createImageData(w, h);
+		const d = imgData.data;
+		for (let i = 0; i < d.length; i += 4) {
+			const v = Math.random() * 255;
+			d[i] = v; d[i + 1] = v; d[i + 2] = v;
+			d[i + 3] = Math.random() < 0.35 ? 12 : 0;
+		}
+		noiseCtx.putImageData(imgData, 0, 0);
+	}
+
+	onMount(() => {
+		const ctx = mainCanvas.getContext('2d')!;
+		const dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+		function resize() {
+			const rect = mainCanvas.getBoundingClientRect();
+			mainCanvas.width = rect.width * dpr;
+			mainCanvas.height = rect.height * dpr;
+			ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+			generateNoise(Math.ceil(rect.width), Math.ceil(rect.height));
+		}
+
+		resize();
+		window.addEventListener('resize', resize);
+		initParticles();
+
+		let frameCount = 0;
+
+		function draw() {
+			const w = mainCanvas.width / dpr;
+			const h = mainCanvas.height / dpr;
+			const cx = w / 2;
+			const cy = h / 2;
+
+			// Audio amplitude
+			if (analyserRef && dataArrayRef) {
+				amplitude = getAmplitude(analyserRef, dataArrayRef);
+			} else {
+				amplitude *= 0.95;
+			}
+			const amp = Math.min(1, amplitude * 3);
+
+			// Fade
+			ctx.fillStyle = 'rgba(0, 0, 0, 0.1)';
+			ctx.fillRect(0, 0, w, h);
+
+			// Migration timer decay
+			if (migrateTimer > 0) {
+				migrateTimer--;
+				if (migrateTimer < 30) {
+					const t = migrateTimer / 30;
+					settleSpeed = SETTLE_SPEED_BASE + (SETTLE_SPEED_BOOST - SETTLE_SPEED_BASE) * t;
+				}
+				if (migrateTimer === 0) settleSpeed = SETTLE_SPEED_BASE;
+			}
+
+			// Smooth layer toggles
+			chladniOpacity += ((showChladni ? 1 : 0) - chladniOpacity) * 0.06;
+			harmonographOpacity += ((showHarmonograph ? 1 : 0) - harmonographOpacity) * 0.06;
+
+			const useModes = currentModes;
+			const useIntervals = currentIntervals;
+
+			// ── CHLADNI PARTICLES (background) ──
+			if (chladniOpacity > 0.01) {
+				const TAU = Math.PI * 2;
+				const currentShake = SHAKE_BASE + amp * SHAKE_AUDIO;
+				const migrating = migrateTimer > 0;
+
+				for (const p of particles) {
+					const val = chladniSuper(p.x, p.y, useModes);
+					const [gx, gy] = chladniGradSuper(p.x, p.y, useModes);
+
+					p.x -= gx * val * settleSpeed;
+					p.y -= gy * val * settleSpeed;
+
+					const nearLine = Math.max(0.3, 1 - Math.abs(val) * 2);
+					const shakeAmp = currentShake * nearLine;
+					p.x += (Math.random() - 0.5) * shakeAmp;
+					p.y += (Math.random() - 0.5) * shakeAmp;
+
+					p.x += (Math.random() - 0.5) * JITTER;
+					p.y += (Math.random() - 0.5) * JITTER;
+
+					if (p.x < 0) p.x += TAU;
+					if (p.x > TAU) p.x -= TAU;
+					if (p.y < 0) p.y += TAU;
+					if (p.y > TAU) p.y -= TAU;
+
+					const sx = (p.x / TAU) * w;
+					const sy = (p.y / TAU) * h;
+					const dist = Math.abs(val);
+					const migrateGlow = migrating ? 0.25 * (dist * 2) : 0;
+					const alpha = Math.min(0.6, Math.max(0.04, 0.35 - dist * 1.5) + migrateGlow);
+
+					ctx.globalAlpha = alpha * chladniOpacity;
+					ctx.fillStyle = migrating ? '#5A4CFF' : '#3A2CFF';
+					ctx.fillRect(sx, sy, migrating ? 1.5 : 1.2, migrating ? 1.5 : 1.2);
+				}
+				ctx.globalAlpha = 1;
+			}
+
+			// ── HARMONOGRAPH (foreground) ──
+			if (harmonographOpacity > 0.01) {
+				const radius = Math.min(cx, cy) * 0.65;
+				const radiusPulse = 1 + amp * 0.12;
+				const glowBoost = amp * 8;
+				const lwBoost = amp * 1.5;
+
+				// Slow rotation
+				rotAngle += 0.0008;
+
+				// Compute trail points
+				const speed = H_SPEED_BASE / Math.max(...useIntervals.map(s => Math.abs(s) || 1), 1);
+
+				// Double-pass rendering: dim wide stroke for bloom, bright thin stroke on top
+				ctx.shadowColor = '#C2FE0C';
+
+				// Pass 1: bloom/glow underlay — wide, dim
+				ctx.shadowBlur = 8 + glowBoost;
+				ctx.strokeStyle = 'rgba(194, 254, 12, 0.25)';
+				ctx.lineWidth = 4.0 + lwBoost;
+
+				const mirrors: [number, number, number][] = [
+					[1, 1, 0.9],
+					[-1, 1, 0.55],
+					[1, -1, 0.55],
+					[-1, -1, 0.35],
+				];
+
+				for (const [mx, my, baseAlpha] of mirrors) {
+					ctx.beginPath();
+					for (let i = 0; i < H_TRAIL; i++) {
+						const t = hPhase - i * speed * 0.5;
+						const [px, py] = harmonograph3D(t, useIntervals, radius * radiusPulse, Math.PI / 4, rotAngle);
+						const x = cx + mx * px;
+						const y = cy + my * py;
+						if (i === 0) ctx.moveTo(x, y);
+						else ctx.lineTo(x, y);
+					}
+					ctx.globalAlpha = Math.min(1, baseAlpha * 0.4) * harmonographOpacity;
+					ctx.stroke();
+				}
+
+				// Pass 2: crisp bright line on top
+				ctx.shadowBlur = 3 + glowBoost * 0.4;
+				ctx.strokeStyle = '#C2FE0C';
+				ctx.lineWidth = 1.5 + lwBoost * 0.5;
+
+				for (const [mx, my, baseAlpha] of mirrors) {
+					ctx.beginPath();
+					for (let i = 0; i < H_TRAIL; i++) {
+						const t = hPhase - i * speed * 0.5;
+						const [px, py] = harmonograph3D(t, useIntervals, radius * radiusPulse, Math.PI / 4, rotAngle);
+						const x = cx + mx * px;
+						const y = cy + my * py;
+						if (i === 0) ctx.moveTo(x, y);
+						else ctx.lineTo(x, y);
+					}
+					ctx.globalAlpha = Math.min(1, baseAlpha) * harmonographOpacity;
+					ctx.stroke();
+				}
+
+				// Head dot
+				const [hx, hy] = harmonograph3D(hPhase, useIntervals, radius * radiusPulse, Math.PI / 4, rotAngle);
+				ctx.beginPath();
+				ctx.arc(cx + hx, cy + hy, 3, 0, Math.PI * 2);
+				ctx.fillStyle = '#C2FE0C';
+				ctx.shadowBlur = 8 + glowBoost;
+				ctx.globalAlpha = harmonographOpacity;
+				ctx.fill();
+
+				ctx.globalAlpha = 1;
+				ctx.shadowBlur = 0;
+
+				hPhase += speed;
+			}
+
+			// ── Noise grain ──
+			if (noiseCanvas && frameCount % 3 === 0) {
+				refreshNoise(Math.ceil(w), Math.ceil(h));
+				ctx.globalAlpha = 0.5;
+				ctx.drawImage(noiseCanvas, 0, 0, w, h);
+				ctx.globalAlpha = 1;
+			}
+
+			// ── Vignette ──
+			const vigR = Math.min(cx, cy) * 0.5;
+			const vigGrad = ctx.createRadialGradient(cx, cy, vigR, cx, cy, Math.max(w, h) * 0.72);
+			vigGrad.addColorStop(0, 'rgba(0,0,0,0)');
+			vigGrad.addColorStop(0.7, 'rgba(0,0,0,0.15)');
+			vigGrad.addColorStop(1, 'rgba(0,0,0,0.55)');
+			ctx.fillStyle = vigGrad;
+			ctx.fillRect(0, 0, w, h);
+
+			frameCount++;
+			animId = requestAnimationFrame(draw);
+		}
+
+		ctx.fillStyle = '#000';
+		ctx.fillRect(0, 0, mainCanvas.width, mainCanvas.height);
+		draw();
+
+		return () => {
+			cancelAnimationFrame(animId);
+			window.removeEventListener('resize', resize);
+		};
+	});
+</script>
+
+<div class="lab">
+	<header class="lab-header">
+		<div class="lab-title">
+			<span class="hud-tag">LAB</span>
+			<h1>CHORD VIZ</h1>
+		</div>
+		<nav class="lab-nav">
+			<a href="{base}/lab" class="lab-nav-link" aria-label="Intervals">INT</a>
+			<a href="{base}/lab/chords" class="lab-nav-link active" aria-label="Chords">CHRD</a>
+			<a href="{base}/lab/scales" class="lab-nav-link" aria-label="Scales">SCALE</a>
+		</nav>
+	</header>
+
+	<div class="canvas-frame">
+		<div class="chord-info">
+			<span class="chord-name">{chord.name}</span>
+			<span class="chord-formula">[{chord.intervals.join(', ')}]</span>
+		</div>
+		<canvas bind:this={mainCanvas}></canvas>
+		<button class="play-btn" class:playing={isPlaying} onclick={handlePlay} aria-label="Play chord">
+			{#if isPlaying}
+				<span class="play-icon pulse">◉</span>
+			{:else}
+				<span class="play-icon">▶</span>
+			{/if}
+		</button>
+		<div class="frame-corner tl"></div>
+		<div class="frame-corner tr"></div>
+		<div class="frame-corner bl"></div>
+		<div class="frame-corner br"></div>
+	</div>
+
+	<div class="selector">
+		{#each CHORDS as ch (ch.id)}
+			<button
+				class="chord-btn"
+				class:active={selected === ch.id}
+				onclick={() => { if (selected === ch.id) handlePlay(); else selected = ch.id; }}
+				aria-label="{ch.name}"
+			>
+				{ch.id}
+			</button>
+		{/each}
+	</div>
+
+	<footer class="lab-footer">
+		<div class="footer-tags">
+			<button class="hud-tag hud-tag--blue" class:dimmed={!showChladni} onclick={() => showChladni = !showChladni}>
+				<span class="toggle-dot" class:on={showChladni}></span>CHLADNI
+			</button>
+			<button class="hud-tag" class:dimmed={!showHarmonograph} onclick={() => showHarmonograph = !showHarmonograph}>
+				<span class="toggle-dot" class:on={showHarmonograph}></span>HARMONOGRAPH
+			</button>
+		</div>
+	</footer>
+</div>
+
+<style>
+	.lab {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		height: 100%;
+	}
+
+	.lab-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.lab-title {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.lab-title h1 {
+		font-family: var(--font-display);
+		font-size: 1.2rem;
+		letter-spacing: 0.15em;
+		color: var(--text-primary);
+	}
+
+	.lab-nav {
+		display: flex;
+		gap: 0.25rem;
+	}
+
+	.lab-nav-link {
+		font-family: var(--mono);
+		font-size: 0.6rem;
+		letter-spacing: 0.08em;
+		padding: 0.2rem 0.4rem;
+		border: 1px solid var(--border-heavy);
+		color: var(--text-secondary);
+		text-decoration: none;
+		transition: all 0.15s ease;
+	}
+
+	.lab-nav-link:hover {
+		border-color: var(--accent);
+		color: var(--text-primary);
+	}
+
+	.lab-nav-link.active {
+		border-color: var(--accent);
+		color: var(--accent);
+		background: var(--accent-dim);
+	}
+
+	.chord-info {
+		position: absolute;
+		top: 0.5rem;
+		left: 0.5rem;
+		z-index: 2;
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+	}
+
+	.chord-name {
+		font-family: var(--mono);
+		font-size: 0.8rem;
+		color: var(--accent);
+		letter-spacing: 0.05em;
+	}
+
+	.chord-formula {
+		font-family: var(--mono);
+		font-size: 0.6rem;
+		color: var(--text-secondary);
+		letter-spacing: 0.08em;
+		opacity: 0.7;
+	}
+
+	.canvas-frame {
+		position: relative;
+		flex: 1;
+		min-height: 0;
+		border: 1px solid var(--border-heavy);
+		background: #000;
+	}
+
+	canvas {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+
+	.frame-corner {
+		position: absolute;
+		width: 12px;
+		height: 12px;
+		border-color: var(--accent);
+		border-style: solid;
+		opacity: 0.4;
+	}
+	.frame-corner.tl { top: -1px; left: -1px; border-width: 2px 0 0 2px; }
+	.frame-corner.tr { top: -1px; right: -1px; border-width: 2px 2px 0 0; }
+	.frame-corner.bl { bottom: -1px; left: -1px; border-width: 0 0 2px 2px; }
+	.frame-corner.br { bottom: -1px; right: -1px; border-width: 0 2px 2px 0; }
+
+	.selector {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+		justify-content: center;
+	}
+
+	.chord-btn {
+		font-family: 'BPdots', var(--mono);
+		font-size: 1.3rem;
+		font-weight: 900;
+		letter-spacing: 0.03em;
+		text-transform: none;
+		padding: 0.15rem 0.4rem 0.35rem 0.5rem;
+		border: 1px solid var(--border-heavy);
+		color: var(--text-secondary);
+		background: var(--surface);
+		transition: all 0.15s ease;
+		min-width: 3rem;
+		text-align: center;
+		line-height: 1;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.chord-btn:hover {
+		border-color: var(--accent);
+		color: var(--text-primary);
+	}
+
+	.chord-btn.active {
+		border-color: var(--accent);
+		color: var(--accent);
+		background: var(--accent-dim);
+	}
+
+	.lab-footer {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.75rem;
+	}
+
+	.footer-tags {
+		display: flex;
+		gap: 0.35rem;
+	}
+
+	.footer-tags .hud-tag {
+		cursor: pointer;
+		transition: opacity 0.15s ease;
+	}
+
+	.footer-tags .hud-tag.dimmed {
+		opacity: 0.3;
+	}
+
+	.toggle-dot {
+		display: inline-block;
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		border: 1px solid currentColor;
+		margin-right: 0.3rem;
+		vertical-align: middle;
+		transition: all 0.15s ease;
+	}
+
+	.toggle-dot.on {
+		background: currentColor;
+		box-shadow: 0 0 4px currentColor;
+	}
+
+	.play-btn {
+		position: absolute;
+		bottom: 0.75rem;
+		right: 0.75rem;
+		z-index: 2;
+		width: 2.5rem;
+		height: 2.5rem;
+		border-radius: 50%;
+		border: 1px solid var(--accent);
+		background: rgba(0, 0, 0, 0.6);
+		color: var(--accent);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		transition: all 0.15s ease;
+		backdrop-filter: blur(4px);
+	}
+
+	.play-btn:hover {
+		background: rgba(194, 254, 12, 0.15);
+		box-shadow: 0 0 12px rgba(194, 254, 12, 0.3);
+	}
+
+	.play-btn.playing {
+		border-color: var(--accent);
+		box-shadow: 0 0 16px rgba(194, 254, 12, 0.4);
+	}
+
+	.play-icon {
+		font-size: 0.9rem;
+		line-height: 1;
+	}
+
+	.play-icon.pulse {
+		animation: pulse-glow 0.6s ease-in-out infinite alternate;
+	}
+
+	@keyframes pulse-glow {
+		from { text-shadow: 0 0 4px var(--accent); }
+		to { text-shadow: 0 0 16px var(--accent), 0 0 24px var(--accent); }
+	}
+</style>

--- a/src/routes/lab/scales/+page.svelte
+++ b/src/routes/lab/scales/+page.svelte
@@ -1,0 +1,572 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { base } from '$app/paths';
+	import { chladniSuper, chladniGradSuper, midiToChladniMode } from '$lib/viz';
+	import type { ChladniMode } from '$lib/viz';
+	import { getAnalyser, getAmplitude } from '$lib/audio';
+
+	// ── Scale definitions ──
+	interface ScaleDef {
+		id: string;
+		name: string;
+		intervals: number[]; // semitones from root
+	}
+
+	const SCALES: ScaleDef[] = [
+		{ id: 'major', name: 'Major', intervals: [0, 2, 4, 5, 7, 9, 11, 12] },
+		{ id: 'minor', name: 'Natural Minor', intervals: [0, 2, 3, 5, 7, 8, 10, 12] },
+		{ id: 'harm-minor', name: 'Harmonic Minor', intervals: [0, 2, 3, 5, 7, 8, 11, 12] },
+		{ id: 'mel-minor', name: 'Melodic Minor', intervals: [0, 2, 3, 5, 7, 9, 11, 12] },
+		{ id: 'dorian', name: 'Dorian', intervals: [0, 2, 3, 5, 7, 9, 10, 12] },
+		{ id: 'mixolydian', name: 'Mixolydian', intervals: [0, 2, 4, 5, 7, 9, 10, 12] },
+		{ id: 'penta-maj', name: 'Major Pentatonic', intervals: [0, 2, 4, 7, 9, 12] },
+		{ id: 'penta-min', name: 'Minor Pentatonic', intervals: [0, 3, 5, 7, 10, 12] },
+		{ id: 'blues', name: 'Blues', intervals: [0, 3, 5, 6, 7, 10, 12] },
+		{ id: 'chromatic', name: 'Chromatic', intervals: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] },
+	];
+
+	const ROOT_MIDI = 60;
+
+	// ── State ──
+	let selected = $state('major');
+	let isPlaying = $state(false);
+	let currentStep = $state(-1); // -1 = idle, 0..n = playing step
+	let mainCanvas: HTMLCanvasElement;
+	let animId: number;
+
+	let scale = $derived(SCALES.find(s => s.id === selected)!);
+
+	// ── Particles ──
+	const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
+	const PARTICLE_COUNT = isMobile ? 1500 : 3500;
+	const SETTLE_SPEED_BASE = 0.003;
+	const SETTLE_SPEED_BOOST = 0.025;
+	const JITTER = 0.001;
+	const SHAKE_BASE = 0.012;
+	let particles: { x: number; y: number }[] = [];
+	let settleSpeed = SETTLE_SPEED_BASE;
+	let migrateTimer = 0;
+
+	// ── Ghost trail: offscreen canvas accumulates past positions ──
+	let ghostCanvas: HTMLCanvasElement | null = null;
+	let ghostCtx: CanvasRenderingContext2D | null = null;
+
+	// ── Audio ──
+	let analyserRef: AnalyserNode | null = null;
+	let dataArrayRef: Uint8Array | null = null;
+	let amplitude = 0;
+
+	// ── Current mode for draw loop ──
+	let currentModes: ChladniMode[] = [{ n: 1, m: 1, amp: 1 }]; // rest state
+
+	function initParticles() {
+		particles = [];
+		const TAU = Math.PI * 2;
+		for (let i = 0; i < PARTICLE_COUNT; i++) {
+			particles.push({ x: Math.random() * TAU, y: Math.random() * TAU });
+		}
+	}
+
+	/** Stamp current particle positions onto ghost canvas */
+	function stampGhost(w: number, h: number, color: string, alpha: number) {
+		if (!ghostCtx) return;
+		const TAU = Math.PI * 2;
+		ghostCtx.fillStyle = color;
+		ghostCtx.globalAlpha = alpha;
+		for (const p of particles) {
+			const sx = (p.x / TAU) * w;
+			const sy = (p.y / TAU) * h;
+			ghostCtx.fillRect(sx, sy, 1, 1);
+		}
+		ghostCtx.globalAlpha = 1;
+	}
+
+	/** Play the scale sequentially — one mode per step */
+	function playScale() {
+		if (isPlaying) return;
+		isPlaying = true;
+		currentStep = 0;
+
+		// Clear ghost trail
+		if (ghostCtx && ghostCanvas) {
+			ghostCtx.fillStyle = '#000';
+			ghostCtx.fillRect(0, 0, ghostCanvas.width, ghostCanvas.height);
+		}
+
+		const intervals = scale.intervals;
+		let step = 0;
+
+		function nextStep() {
+			if (step >= intervals.length) {
+				// Hold final composite for a moment
+				currentStep = -1;
+				setTimeout(() => { isPlaying = false; }, 2000);
+				return;
+			}
+
+			const midi = ROOT_MIDI + intervals[step];
+			const [n, m] = midiToChladniMode(midi);
+			currentModes = [{ n, m, amp: 1 }];
+			currentStep = step;
+
+			// Stamp ghost of current position before migration
+			if (mainCanvas) {
+				const dpr = Math.min(window.devicePixelRatio || 1, 2);
+				const w = mainCanvas.width / dpr;
+				const h = mainCanvas.height / dpr;
+				// Color cycles through scale degrees — warm to cool
+				const hue = (step / intervals.length) * 240; // 0=red → 240=blue
+				stampGhost(w, h, `hsl(${hue}, 80%, 50%)`, 0.15);
+			}
+
+			// Boost settle for migration
+			settleSpeed = SETTLE_SPEED_BOOST;
+			migrateTimer = 60;
+
+			// Play the note (simple sine via AudioContext)
+			playNote(midi);
+
+			step++;
+			setTimeout(nextStep, 500); // 500ms per note
+		}
+
+		nextStep();
+	}
+
+	/** Simple note playback for scale demo */
+	function playNote(midi: number) {
+		const freq = 440 * Math.pow(2, (midi - 69) / 12);
+		const audioCtx = new (window.AudioContext || (window as any).webkitAudioContext)();
+		const osc = audioCtx.createOscillator();
+		const gain = audioCtx.createGain();
+		osc.type = 'triangle';
+		osc.frequency.value = freq;
+		gain.gain.setValueAtTime(0, audioCtx.currentTime);
+		gain.gain.linearRampToValueAtTime(0.25, audioCtx.currentTime + 0.02);
+		gain.gain.exponentialRampToValueAtTime(0.01, audioCtx.currentTime + 0.45);
+		osc.connect(gain);
+		gain.connect(audioCtx.destination);
+		osc.start();
+		osc.stop(audioCtx.currentTime + 0.5);
+	}
+
+	// React to scale selection change
+	let firstRun = true;
+	$effect(() => {
+		const s = scale;
+		// Reset to root mode
+		const [n, m] = midiToChladniMode(ROOT_MIDI + s.intervals[0]);
+		currentModes = [{ n, m, amp: 1 }];
+		settleSpeed = SETTLE_SPEED_BOOST;
+		migrateTimer = 90;
+		if (particles.length === 0) initParticles();
+		firstRun = false;
+	});
+
+	// ── Noise ──
+	let noiseCanvas: HTMLCanvasElement | null = null;
+	let noiseCtx: CanvasRenderingContext2D | null = null;
+
+	function generateNoise(w: number, h: number) {
+		if (!noiseCanvas) {
+			noiseCanvas = document.createElement('canvas');
+			noiseCtx = noiseCanvas.getContext('2d')!;
+		}
+		noiseCanvas.width = w;
+		noiseCanvas.height = h;
+	}
+
+	function refreshNoise(w: number, h: number) {
+		if (!noiseCtx || !noiseCanvas) return;
+		const imgData = noiseCtx.createImageData(w, h);
+		const d = imgData.data;
+		for (let i = 0; i < d.length; i += 4) {
+			const v = Math.random() * 255;
+			d[i] = v; d[i + 1] = v; d[i + 2] = v;
+			d[i + 3] = Math.random() < 0.35 ? 12 : 0;
+		}
+		noiseCtx.putImageData(imgData, 0, 0);
+	}
+
+	onMount(() => {
+		const ctx = mainCanvas.getContext('2d')!;
+		const dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+		// Ghost trail canvas
+		ghostCanvas = document.createElement('canvas');
+		ghostCtx = ghostCanvas.getContext('2d')!;
+
+		function resize() {
+			const rect = mainCanvas.getBoundingClientRect();
+			const pw = rect.width * dpr;
+			const ph = rect.height * dpr;
+			mainCanvas.width = pw;
+			mainCanvas.height = ph;
+			ghostCanvas!.width = pw;
+			ghostCanvas!.height = ph;
+			ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+			ghostCtx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+			generateNoise(Math.ceil(rect.width), Math.ceil(rect.height));
+		}
+
+		resize();
+		window.addEventListener('resize', resize);
+		initParticles();
+
+		let frameCount = 0;
+
+		function draw() {
+			const w = mainCanvas.width / dpr;
+			const h = mainCanvas.height / dpr;
+
+			// Audio amplitude
+			if (analyserRef && dataArrayRef) {
+				amplitude = getAmplitude(analyserRef, dataArrayRef);
+			} else {
+				amplitude *= 0.95;
+			}
+
+			// Fade
+			ctx.fillStyle = 'rgba(0, 0, 0, 0.1)';
+			ctx.fillRect(0, 0, w, h);
+
+			// Migration timer decay
+			if (migrateTimer > 0) {
+				migrateTimer--;
+				if (migrateTimer < 20) {
+					settleSpeed = SETTLE_SPEED_BASE + (SETTLE_SPEED_BOOST - SETTLE_SPEED_BASE) * (migrateTimer / 20);
+				}
+				if (migrateTimer === 0) settleSpeed = SETTLE_SPEED_BASE;
+			}
+
+			// ── Draw ghost trail (underneath everything) ──
+			if (ghostCanvas) {
+				ctx.globalAlpha = 0.6;
+				ctx.drawImage(ghostCanvas, 0, 0, w, h);
+				ctx.globalAlpha = 1;
+			}
+
+			// ── Chladni particles ──
+			const TAU = Math.PI * 2;
+			const useModes = currentModes;
+			const migrating = migrateTimer > 0;
+
+			for (const p of particles) {
+				const val = chladniSuper(p.x, p.y, useModes);
+				const [gx, gy] = chladniGradSuper(p.x, p.y, useModes);
+
+				p.x -= gx * val * settleSpeed;
+				p.y -= gy * val * settleSpeed;
+
+				const nearLine = Math.max(0.3, 1 - Math.abs(val) * 2);
+				const shakeAmp = SHAKE_BASE * nearLine;
+				p.x += (Math.random() - 0.5) * shakeAmp;
+				p.y += (Math.random() - 0.5) * shakeAmp;
+
+				p.x += (Math.random() - 0.5) * JITTER;
+				p.y += (Math.random() - 0.5) * JITTER;
+
+				if (p.x < 0) p.x += TAU;
+				if (p.x > TAU) p.x -= TAU;
+				if (p.y < 0) p.y += TAU;
+				if (p.y > TAU) p.y -= TAU;
+
+				const sx = (p.x / TAU) * w;
+				const sy = (p.y / TAU) * h;
+				const dist = Math.abs(val);
+				const migrateGlow = migrating ? 0.3 * (dist * 2) : 0;
+				const alpha = Math.min(0.7, Math.max(0.05, 0.4 - dist * 1.5) + migrateGlow);
+
+				ctx.globalAlpha = alpha;
+				ctx.fillStyle = migrating ? '#C2FE0C' : '#3A2CFF';
+				const pSize = migrating ? 1.6 : 1.2;
+				ctx.fillRect(sx, sy, pSize, pSize);
+			}
+			ctx.globalAlpha = 1;
+
+			// ── Step indicator ──
+			if (currentStep >= 0 && isPlaying) {
+				const stepFrac = currentStep / (scale.intervals.length - 1);
+				ctx.fillStyle = `hsl(${stepFrac * 240}, 80%, 60%)`;
+				ctx.font = '11px var(--mono)';
+				ctx.globalAlpha = 0.8;
+				const label = `♪ ${currentStep + 1}/${scale.intervals.length}`;
+				ctx.fillText(label, 8, h - 8);
+				ctx.globalAlpha = 1;
+			}
+
+			// ── Noise grain ──
+			if (noiseCanvas && frameCount % 3 === 0) {
+				refreshNoise(Math.ceil(w), Math.ceil(h));
+				ctx.globalAlpha = 0.5;
+				ctx.drawImage(noiseCanvas, 0, 0, w, h);
+				ctx.globalAlpha = 1;
+			}
+
+			// ── Vignette ──
+			const cx = w / 2, cy = h / 2;
+			const vigR = Math.min(cx, cy) * 0.5;
+			const vigGrad = ctx.createRadialGradient(cx, cy, vigR, cx, cy, Math.max(w, h) * 0.72);
+			vigGrad.addColorStop(0, 'rgba(0,0,0,0)');
+			vigGrad.addColorStop(0.7, 'rgba(0,0,0,0.15)');
+			vigGrad.addColorStop(1, 'rgba(0,0,0,0.55)');
+			ctx.fillStyle = vigGrad;
+			ctx.fillRect(0, 0, w, h);
+
+			frameCount++;
+			animId = requestAnimationFrame(draw);
+		}
+
+		ctx.fillStyle = '#000';
+		ctx.fillRect(0, 0, mainCanvas.width, mainCanvas.height);
+		draw();
+
+		return () => {
+			cancelAnimationFrame(animId);
+			window.removeEventListener('resize', resize);
+		};
+	});
+</script>
+
+<div class="lab">
+	<header class="lab-header">
+		<div class="lab-title">
+			<span class="hud-tag">LAB</span>
+			<h1>SCALE VIZ</h1>
+		</div>
+		<nav class="lab-nav">
+			<a href="{base}/lab" class="lab-nav-link" aria-label="Intervals">INT</a>
+			<a href="{base}/lab/chords" class="lab-nav-link" aria-label="Chords">CHRD</a>
+			<a href="{base}/lab/scales" class="lab-nav-link active" aria-label="Scales">SCALE</a>
+		</nav>
+	</header>
+
+	<div class="scale-info">
+		<span class="scale-name">{scale.name}</span>
+		<span class="scale-formula">{scale.intervals.join(' ')}</span>
+	</div>
+
+	<div class="canvas-frame">
+		<canvas bind:this={mainCanvas}></canvas>
+		<button class="play-btn" class:playing={isPlaying} onclick={playScale} disabled={isPlaying} aria-label="Play scale">
+			{#if isPlaying}
+				<span class="play-icon pulse">◉</span>
+			{:else}
+				<span class="play-icon">▶</span>
+			{/if}
+		</button>
+		<div class="frame-corner tl"></div>
+		<div class="frame-corner tr"></div>
+		<div class="frame-corner bl"></div>
+		<div class="frame-corner br"></div>
+	</div>
+
+	<div class="selector">
+		{#each SCALES as s (s.id)}
+			<button
+				class="scale-btn"
+				class:active={selected === s.id}
+				onclick={() => selected = s.id}
+				aria-label="{s.name}"
+			>
+				{s.id}
+			</button>
+		{/each}
+	</div>
+
+	<footer class="lab-footer">
+		<span class="hud-tag hud-tag--blue">PROGRESSIVE CHLADNI</span>
+		{#if isPlaying}
+			<span class="hud-tag" style="color: #C2FE0C;">PLAYING</span>
+		{/if}
+	</footer>
+</div>
+
+<style>
+	.lab {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		height: 100%;
+	}
+
+	.lab-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.lab-title {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.lab-title h1 {
+		font-family: var(--font-display);
+		font-size: 1.2rem;
+		letter-spacing: 0.15em;
+		color: var(--text-primary);
+	}
+
+	.lab-nav {
+		display: flex;
+		gap: 0.25rem;
+	}
+
+	.lab-nav-link {
+		font-family: var(--mono);
+		font-size: 0.6rem;
+		letter-spacing: 0.08em;
+		padding: 0.2rem 0.4rem;
+		border: 1px solid var(--border-heavy);
+		color: var(--text-secondary);
+		text-decoration: none;
+		transition: all 0.15s ease;
+	}
+
+	.lab-nav-link:hover {
+		border-color: var(--accent);
+		color: var(--text-primary);
+	}
+
+	.lab-nav-link.active {
+		border-color: var(--accent);
+		color: var(--accent);
+		background: var(--accent-dim);
+	}
+
+	.scale-info {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+	}
+
+	.scale-name {
+		font-family: var(--mono);
+		font-size: 0.8rem;
+		color: var(--accent);
+		letter-spacing: 0.05em;
+	}
+
+	.scale-formula {
+		font-family: var(--mono);
+		font-size: 0.6rem;
+		color: var(--text-secondary);
+		letter-spacing: 0.06em;
+	}
+
+	.canvas-frame {
+		position: relative;
+		flex: 1;
+		min-height: 0;
+		border: 1px solid var(--border-heavy);
+		background: #000;
+	}
+
+	canvas {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+
+	.frame-corner {
+		position: absolute;
+		width: 12px;
+		height: 12px;
+		border-color: var(--accent);
+		border-style: solid;
+		opacity: 0.4;
+	}
+	.frame-corner.tl { top: -1px; left: -1px; border-width: 2px 0 0 2px; }
+	.frame-corner.tr { top: -1px; right: -1px; border-width: 2px 2px 0 0; }
+	.frame-corner.bl { bottom: -1px; left: -1px; border-width: 0 0 2px 2px; }
+	.frame-corner.br { bottom: -1px; right: -1px; border-width: 0 2px 2px 0; }
+
+	.selector {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+		justify-content: center;
+	}
+
+	.scale-btn {
+		font-family: var(--mono);
+		font-size: 0.7rem;
+		font-weight: 600;
+		letter-spacing: 0.03em;
+		text-transform: none;
+		padding: 0.25rem 0.45rem;
+		border: 1px solid var(--border-heavy);
+		color: var(--text-secondary);
+		background: var(--surface);
+		transition: all 0.15s ease;
+		text-align: center;
+		line-height: 1.2;
+	}
+
+	.scale-btn:hover {
+		border-color: var(--accent);
+		color: var(--text-primary);
+	}
+
+	.scale-btn.active {
+		border-color: var(--accent);
+		color: var(--accent);
+		background: var(--accent-dim);
+	}
+
+	.lab-footer {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.75rem;
+	}
+
+	.play-btn {
+		position: absolute;
+		bottom: 0.75rem;
+		right: 0.75rem;
+		z-index: 2;
+		width: 2.5rem;
+		height: 2.5rem;
+		border-radius: 50%;
+		border: 1px solid var(--accent);
+		background: rgba(0, 0, 0, 0.6);
+		color: var(--accent);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		transition: all 0.15s ease;
+		backdrop-filter: blur(4px);
+	}
+
+	.play-btn:hover:not(:disabled) {
+		background: rgba(194, 254, 12, 0.15);
+		box-shadow: 0 0 12px rgba(194, 254, 12, 0.3);
+	}
+
+	.play-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.play-btn.playing {
+		border-color: var(--accent);
+		box-shadow: 0 0 16px rgba(194, 254, 12, 0.4);
+	}
+
+	.play-icon {
+		font-size: 0.9rem;
+		line-height: 1;
+	}
+
+	.play-icon.pulse {
+		animation: pulse-glow 0.6s ease-in-out infinite alternate;
+	}
+
+	@keyframes pulse-glow {
+		from { text-shadow: 0 0 4px var(--accent); }
+		to { text-shadow: 0 0 16px var(--accent), 0 0 24px var(--accent); }
+	}
+</style>


### PR DESCRIPTION
## Summary

Visualization R&D for multi-note visual representations, prototyped on `/lab`.

### Chord Visualization (`/lab/chords`)
- **Superposition Chladni**: particles settle on combined nodal patterns of all chord tones
- **3D Harmonograph**: Lissajous curves extended to 3+ frequencies with isometric projection
- Triads: one frequency per axis. Tetrads: root triad + extension modulation
- Double-pass bloom rendering for visibility on dark/OLED backgrounds
- All 10 chord types produce distinct visual signatures

### Scale Visualization (`/lab/scales`)
- **Progressive Chladni**: particles migrate through modes as each scale degree plays
- **Ghost trails** accumulate in a hue gradient (red→blue), creating unique scale fingerprints
- 10 scales: major, minor variants, modes, pentatonics, blues, chromatic

### Shared Infrastructure
- `viz.ts`: `chladniSuper()`, `chladniGradSuper()`, `chordToModes()`, `harmonograph3D()`, `jiRatio()`, `midiToChladniMode()`
- Lab sub-navigation (INT / CHRD / SCALE tabs)
- Audio-reactive particles and curves, 4-way mirror symmetry

### Testing
- Build: ✅ clean
- Tests: ✅ 188/188 passing
- QA: Palm reviewed on staging — all chord/scale types render distinct patterns
- Rebased cleanly on current main (includes v3.4 scale quiz system)

### Files Changed
- `src/lib/viz.ts` — superposition + harmonograph math
- `src/components/QuizViz.svelte` — quiz interval visualization
- `src/components/ChladniCanvas.svelte` — standalone Chladni component
- `src/routes/lab/+page.svelte` — added sub-nav
- `src/routes/lab/chords/+page.svelte` — new chord viz page
- `src/routes/lab/scales/+page.svelte` — new scale viz page