### PR TITLE
fix: home page scrollbar overflow from 3-way switcher

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -227,7 +227,7 @@
 <style>
 	.home {
 		display: flex; flex-direction: column; align-items: center;
-		justify-content: center; height: 100%; gap: 2.5rem; text-align: center;
+		justify-content: center; height: 100%; gap: 1.5rem; text-align: center;
 	}
 	.title-block { position: relative; }
 	.title {


### PR DESCRIPTION
Home page gap reduced from 2.5rem to 1.5rem. The 3-way content switcher added enough height to push content past 100% of the viewport, causing a scrollbar. 1 line change. 188 tests passing.