### PR TITLE
fix: widen hDim7 column from 4rem to 5.5rem in chord quiz

### DIFF
--- a/src/routes/quiz/chords/+page.svelte
+++ b/src/routes/quiz/chords/+page.svelte
@@ -550,7 +550,7 @@
 	}
 	.missed-card-content {
 		position: relative; z-index: 1;
-		display: grid; grid-template-columns: 4rem 1fr auto;
+		display: grid; grid-template-columns: 5.5rem 1fr auto;
 		align-items: center; gap: 0.75rem; padding: 0.7rem 0.85rem;
 	}
 	.missed-id {


### PR DESCRIPTION
Widens the missed-cards grid first column in `quiz/chords/+page.svelte` from `4rem` to `5.5rem` so the 5-char `hDim7` label fits without overflow. Matches the `ChordCard` component which already uses `5.5rem`.

1 file changed, 1 line.