### PR TITLE
fix: 3 viz polish items — round 3

### DIFF
--- a/src/routes/lab/+page.svelte
+++ b/src/routes/lab/+page.svelte
@@ -62,6 +62,9 @@
 	for (let i = 0; i < 600; i++) dissolveOffsets.push({ x: 0, y: 0 });
 	let isPlaying = $state(false);
 
+	// Playback generation counter (for aborting overlapping plays)
+	let playGeneration = 0;
+
 	// Lissajous morphing — rest state is 1:1 circle, playing morphs to interval ratio
 	let morphT = $state(0);  // 0 = rest (circle), 1 = full interval shape
 	let morphTarget = 0;
@@ -73,6 +76,9 @@
 			analyserRef = analyser;
 			dataArrayRef = dataArray;
 		}
+
+		playGeneration++;
+		const thisGen = playGeneration;
 
 		const state = loadState();
 		const rootMidi = 60;
@@ -107,7 +113,7 @@
 		}, 700);
 
 		playInterval(rootMidi, intervalSemitones, 'ascending', state.settings.toneType);
-		setTimeout(() => { isPlaying = false; }, 2000);
+		setTimeout(() => { if (thisGen === playGeneration) isPlaying = false; }, 2000);
 	}
 
 	// Chladni — reduce particles on mobile for perf

--- a/src/routes/lab/chords/+page.svelte
+++ b/src/routes/lab/chords/+page.svelte
@@ -13,6 +13,9 @@
 	let showHarmonograph = $state(true);
 	let isPlaying = $state(false);
 
+	// Playback generation counter (for aborting overlapping plays)
+	let playGeneration = 0;
+
 	const ROOT_MIDI = 60; // C4
 
 	let chord = $derived(CHORDS.find(c => c.id === selected)!);
@@ -67,11 +70,13 @@
 			analyserRef = analyser;
 			dataArrayRef = dataArray;
 		}
+		playGeneration++;
+		const thisGen = playGeneration;
 		isPlaying = true;
 		playChord(ROOT_MIDI, chord.intervals, 'root', 'epiano', false);
 		settleSpeed = SETTLE_SPEED_BOOST;
 		migrateTimer = 120;
-		setTimeout(() => { isPlaying = false; }, 2000);
+		setTimeout(() => { if (thisGen === playGeneration) isPlaying = false; }, 2000);
 	}
 
 	// React to chord changes

--- a/src/routes/lab/scales/+page.svelte
+++ b/src/routes/lab/scales/+page.svelte
@@ -374,7 +374,7 @@
 			<button
 				class="scale-btn"
 				class:active={selected === s.id}
-				onclick={() => selected = s.id}
+				onclick={() => { if (selected === s.id) playScale(); else selected = s.id; }}
 				aria-label="{s.name}"
 			>
 				{s.id}
@@ -387,9 +387,6 @@
 			<span class="hud-tag hud-tag--blue">
 				<span class="toggle-dot on"></span>PROGRESSIVE CHLADNI
 			</span>
-			{#if isPlaying}
-				<span class="hud-tag" style="color: #C2FE0C;">PLAYING</span>
-			{/if}
 		</div>
 	</footer>
 </div>


### PR DESCRIPTION
### Bug 1 — Remove PLAYING tag
Removed from scale page footer. Redundant now that play button is gone.

### Bug 2 — Replay same scale
Clicking already-selected scale now calls `playScale()` directly (was no-op because same `$state` value doesn't trigger `$effect`).

### Bug 3 — Interruptible playback on all pages
Added `playGeneration` counter to interval and chord pages (matching scale page). Switching mid-play starts the new selection immediately. Old audio decays naturally.

- Build: ✅ | Tests: ✅ 188/188 | 3 files, +14/-6