### PR TITLE
fix: 3 viz polish items — round 5

### DIFF
--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -430,6 +430,17 @@ function playPianoToneToNode(
 }
 
 /**
+ * Stop all active audio by suspending the AudioContext.
+ * Call from page cleanup to silence playback on navigation.
+ * The context resumes automatically on next play via getContext().
+ */
+export function stopAudio(): void {
+	if (ctx && ctx.state === 'running') {
+		ctx.suspend();
+	}
+}
+
+/**
  * Warm up the AudioContext on first user interaction.
  * Call this once from a top-level touch/click handler to ensure
  * iOS Safari has unlocked audio before the user reaches the quiz.
@@ -528,6 +539,35 @@ export function playChord(
 		const offset = arpeggiated ? i * arpDelay : Math.random() * 0.015; // humanization for block
 		playToNode(freq, now + offset, noteDuration, audioCtx, masterGain);
 	});
+}
+
+/**
+ * Play a single note through the master output (analyser-connected).
+ * Use for scale visualization where each note needs individual timing control.
+ */
+export function playNote(
+	midi: number,
+	toneType: ToneType = 'epiano',
+	duration: number = 0.5
+): void {
+	const audioCtx = getContext();
+	const master = getMasterOutput();
+	const now = audioCtx.currentTime;
+	const freq = midiToFreq(midi);
+
+	const noteGain = audioCtx.createGain();
+	noteGain.gain.setValueAtTime(1, now);
+	noteGain.gain.setValueAtTime(1, now + duration - 0.03);
+	noteGain.gain.linearRampToValueAtTime(0, now + duration);
+	noteGain.connect(master);
+
+	if (toneType === 'piano') {
+		playPianoToneToNode(freq, now, duration, audioCtx, noteGain);
+	} else if (toneType === 'epiano') {
+		playEpianoToneToNode(freq, now, duration, audioCtx, noteGain);
+	} else {
+		playSineToneToNode(freq, now, duration, audioCtx, noteGain);
+	}
 }
 
 /**

--- a/src/routes/lab/+page.svelte
+++ b/src/routes/lab/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { base } from '$app/paths';
 	import { INTERVALS } from '$lib/intervals';
-	import { playInterval, getAnalyser, getAmplitude } from '$lib/audio';
+	import { playInterval, getAnalyser, getAmplitude, stopAudio } from '$lib/audio';
 	import { loadState } from '$lib/state';
 
 	// Just intonation ratios — [numerator, denominator]
@@ -445,6 +445,7 @@
 		return () => {
 			cancelAnimationFrame(animId);
 			window.removeEventListener('resize', resize);
+			stopAudio();
 		};
 	});
 </script>
@@ -463,6 +464,10 @@
 	</header>
 
 	<div class="canvas-frame">
+		<div class="interval-info">
+			<span class="interval-name">{intervalName}</span>
+			<span class="interval-ratio">{ratioLabel}</span>
+		</div>
 		<canvas bind:this={mainCanvas}></canvas>
 		<button class="play-btn" class:playing={isPlaying} onclick={handlePlay} aria-label="Play interval">
 			{#if isPlaying}
@@ -582,6 +587,31 @@
 		font-size: 0.75rem;
 		color: var(--text-secondary);
 		letter-spacing: 0.1em;
+	}
+
+	.interval-info {
+		position: absolute;
+		top: 0.5rem;
+		left: 0.5rem;
+		z-index: 2;
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+	}
+
+	.interval-name {
+		font-family: var(--mono);
+		font-size: 0.8rem;
+		color: var(--accent);
+		letter-spacing: 0.05em;
+	}
+
+	.interval-ratio {
+		font-family: var(--mono);
+		font-size: 0.6rem;
+		color: var(--text-secondary);
+		letter-spacing: 0.08em;
+		opacity: 0.7;
 	}
 
 	.canvas-frame {

--- a/src/routes/lab/chords/+page.svelte
+++ b/src/routes/lab/chords/+page.svelte
@@ -4,8 +4,7 @@
 	import { CHORDS } from '$lib/chords';
 	import { chladniSuper, chladniGradSuper, chordToModes, harmonograph3D } from '$lib/viz';
 	import type { ChladniMode } from '$lib/viz';
-	import { playChord } from '$lib/audio';
-	import { getAnalyser, getAmplitude } from '$lib/audio';
+	import { playChord, getAnalyser, getAmplitude, stopAudio } from '$lib/audio';
 
 	// ── State ──
 	let selected = $state('maj');
@@ -314,6 +313,7 @@
 		return () => {
 			cancelAnimationFrame(animId);
 			window.removeEventListener('resize', resize);
+			stopAudio();
 		};
 	});
 </script>

--- a/src/routes/lab/scales/+page.svelte
+++ b/src/routes/lab/scales/+page.svelte
@@ -3,7 +3,8 @@
 	import { base } from '$app/paths';
 	import { chladniSuper, chladniGradSuper, midiToChladniMode } from '$lib/viz';
 	import type { ChladniMode } from '$lib/viz';
-	import { getAnalyser, getAmplitude, playInterval } from '$lib/audio';
+	import { getAnalyser, getAmplitude, playNote, stopAudio } from '$lib/audio';
+	import { loadState } from '$lib/state';
 
 	// ── Scale definitions ──
 	interface ScaleDef {
@@ -142,8 +143,9 @@
 			settleSpeed = SETTLE_SPEED_BOOST;
 			migrateTimer = 60;
 
-			// Play the note through shared audio (analyser-connected)
-			playInterval(midi, 0, 'ascending', 'sine');
+			// Play the note through shared audio (analyser-connected, respects tone setting)
+			const state = loadState();
+			playNote(midi, state.settings.toneType, 0.45);
 
 			step++;
 			setTimeout(nextStep, 500); // 500ms per note
@@ -322,6 +324,7 @@
 		return () => {
 			cancelAnimationFrame(animId);
 			window.removeEventListener('resize', resize);
+			stopAudio();
 		};
 	});
 </script>


### PR DESCRIPTION
### Bug 1 — Scale audio regression (priority)
Root cause: `playInterval(midi, 0, 'ascending', 'sine')` played two sequential notes (unison interval) with hardcoded sine tone. Added `playNote()` to `audio.ts` — plays a single note through the master output, respects the user's `toneType` setting.

### Bug 2 — Interval page info overlay
Added interval name + ratio overlay to the interval canvas (top-left, matching chord/scale pages). E.g. "Perfect 5th" / "3 : 2".

### Bug 3 — Stop audio on navigation
Added `stopAudio()` to `audio.ts` (suspends AudioContext). Called from all three lab pages' `onMount` cleanup — audio stops when navigating away.

- Build: ✅ | Tests: ✅ 188/188 | 4 files, +79/-6