### PR TITLE
fix: audio actually stops on page navigation

### DIFF
--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -430,13 +430,16 @@ function playPianoToneToNode(
 }
 
 /**
- * Stop all active audio by suspending the AudioContext.
- * Call from page cleanup to silence playback on navigation.
- * The context resumes automatically on next play via getContext().
+ * Stop all active audio by closing the AudioContext.
+ * Creates a fresh context on next play. This fully stops all
+ * scheduled oscillators (suspend() alone doesn't cancel them).
  */
 export function stopAudio(): void {
-	if (ctx && ctx.state === 'running') {
-		ctx.suspend();
+	if (ctx) {
+		ctx.close();
+		ctx = null;
+		analyserNode = null;
+		masterOutput = null;
 	}
 }
 

--- a/src/routes/lab/+page.svelte
+++ b/src/routes/lab/+page.svelte
@@ -445,6 +445,8 @@
 		return () => {
 			cancelAnimationFrame(animId);
 			window.removeEventListener('resize', resize);
+			analyserRef = null;
+			dataArrayRef = null;
 			stopAudio();
 		};
 	});

--- a/src/routes/lab/chords/+page.svelte
+++ b/src/routes/lab/chords/+page.svelte
@@ -313,6 +313,8 @@
 		return () => {
 			cancelAnimationFrame(animId);
 			window.removeEventListener('resize', resize);
+			analyserRef = null;
+			dataArrayRef = null;
 			stopAudio();
 		};
 	});

--- a/src/routes/lab/scales/+page.svelte
+++ b/src/routes/lab/scales/+page.svelte
@@ -324,6 +324,11 @@
 		return () => {
 			cancelAnimationFrame(animId);
 			window.removeEventListener('resize', resize);
+			// Kill any in-progress scale playback
+			playGeneration++;
+			isPlaying = false;
+			analyserRef = null;
+			dataArrayRef = null;
 			stopAudio();
 		};
 	});


### PR DESCRIPTION
PR #11's `stopAudio()` used `AudioContext.suspend()` which pauses but doesn't cancel scheduled oscillators — they resume on next play. 

Changed to `AudioContext.close()` which fully terminates all audio. Context + analyser + master output are nulled and recreated fresh on next interaction.

Scale page cleanup also bumps `playGeneration` to kill the `setTimeout` note chain.

- Build: ✅ | Tests: ✅ 188/188 | 4 files, +17/-5