### PR TITLE
fix: iOS safe area insets for standalone PWA mode

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -35,6 +35,8 @@
 		position: relative;
 		display: flex; flex-direction: column; height: 100dvh;
 		max-width: 480px; margin: 0 auto;
+		padding-top: env(safe-area-inset-top);
+		padding-bottom: env(safe-area-inset-bottom);
 	}
 	.content {
 		flex: 1; overflow-y: auto; padding: 1.5rem 1.25rem;


### PR DESCRIPTION
Content was bleeding into the iOS status bar when launched as standalone PWA (Add to Home Screen). The LAB toggle at top was unreachable.

Fix: add `padding-top: env(safe-area-inset-top)` and `padding-bottom: env(safe-area-inset-bottom)` to the `.app` container in the layout. Dark background extends behind the translucent status bar, content pushed below it.

1 file changed, 2 lines. 188/188 tests passing.