### PR TITLE
fix: move bottom safe area inset from .app to BottomNav

### DIFF
--- a/src/components/BottomNav.svelte
+++ b/src/components/BottomNav.svelte
@@ -38,6 +38,7 @@
 <style>
 	.bottom-nav {
 		background: var(--surface);
+		padding-bottom: env(safe-area-inset-bottom);
 	}
 	.nav-tabs {
 		display: flex; justify-content: center; gap: 2px;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -36,7 +36,6 @@
 		display: flex; flex-direction: column; height: 100dvh;
 		max-width: 480px; margin: 0 auto;
 		padding-top: env(safe-area-inset-top);
-		padding-bottom: env(safe-area-inset-bottom);
 	}
 	.content {
 		flex: 1; overflow-y: auto; padding: 1.5rem 1.25rem;


### PR DESCRIPTION
Fixes the double-anchoring issue on iOS standalone PWA mode where the bottom nav jumped between two positions on scroll.

Root cause: `env(safe-area-inset-bottom)` was on the `.app` container, creating padding that shifted the entire layout. When iOS transitions between gesture states, this caused a visible jump.

Fix: Move the bottom inset to the BottomNav component itself. The nav's dark background extends into the safe area, buttons stay above the home indicator. No double-apply, no jump.

2 files, 1-line diff each. 188/188 tests passing.