### PR TITLE
fix: compact bottom nav padding in standalone PWA mode

### DIFF
--- a/src/components/BottomNav.svelte
+++ b/src/components/BottomNav.svelte
@@ -40,6 +40,14 @@
 		background: var(--surface);
 		padding-bottom: env(safe-area-inset-bottom);
 	}
+	/* In standalone PWA mode, skip the dynamic env value which starts
+	   oversized on iOS and snaps down after a gesture. Use a small
+	   fixed padding that clears the home indicator from the start. */
+	@media all and (display-mode: standalone) {
+		.bottom-nav {
+			padding-bottom: 0.35rem;
+		}
+	}
 	.nav-tabs {
 		display: flex; justify-content: center; gap: 2px;
 	}


### PR DESCRIPTION
In iOS standalone mode, `env(safe-area-inset-bottom)` starts oversized (full toolbar height) and snaps down to compact after a scroll gesture, causing a visible jump.

Fix: use `@media (display-mode: standalone)` to apply a fixed `0.35rem` bottom padding in PWA mode. Regular Safari browser still uses the dynamic `env()` value.

1 file changed. 188/188 tests passing.