### PR TITLE
revert: remove bottom safe area padding from BottomNav

### DIFF
--- a/src/components/BottomNav.svelte
+++ b/src/components/BottomNav.svelte
@@ -38,15 +38,6 @@
 <style>
 	.bottom-nav {
 		background: var(--surface);
-		padding-bottom: env(safe-area-inset-bottom);
-	}
-	/* In standalone PWA mode, skip the dynamic env value which starts
-	   oversized on iOS and snaps down after a gesture. Use a small
-	   fixed padding that clears the home indicator from the start. */
-	@media all and (display-mode: standalone) {
-		.bottom-nav {
-			padding-bottom: 0.35rem;
-		}
 	}
 	.nav-tabs {
 		display: flex; justify-content: center; gap: 2px;


### PR DESCRIPTION
Reverts bottom safe area changes from PRs #18 and #19. Mike confirmed these caused incorrect initial height in iOS standalone PWA mode.

Top safe area (PR #17) is kept and working.

1 file changed. 188/188 tests passing.