### PR TITLE
fix: bottom safe area — single apply on BottomNav only

### DIFF
--- a/src/components/BottomNav.svelte
+++ b/src/components/BottomNav.svelte
@@ -38,6 +38,7 @@
 <style>
 	.bottom-nav {
 		background: var(--surface);
+		padding-bottom: env(safe-area-inset-bottom);
 	}
 	.nav-tabs {
 		display: flex; justify-content: center; gap: 2px;


### PR DESCRIPTION
One line: padding-bottom: env(safe-area-inset-bottom) on BottomNav. Nothing else. 188/188 tests.