### PR TITLE
revert: remove bottom safe area (deferred)

### DIFF
--- a/src/components/BottomNav.svelte
+++ b/src/components/BottomNav.svelte
@@ -38,7 +38,6 @@
 <style>
 	.bottom-nav {
 		background: var(--surface);
-		padding-bottom: env(safe-area-inset-bottom);
 	}
 	.nav-tabs {
 		display: flex; justify-content: center; gap: 2px;


### PR DESCRIPTION
Bottom safe area causes incorrect initial height in iOS standalone PWA. WebKit limitation. Shipping without it.