### PR TITLE
perf: Chladni idle pause + light mode + remove vignette

### DIFF
--- a/src/components/VizQuizLayout.svelte
+++ b/src/components/VizQuizLayout.svelte
@@ -401,8 +401,8 @@
 			// ── SCANLINE FLICKER ──
 			if (frameCount % 120 < 2) {
 				const glitchY = Math.random() * h;
-				ctx.fillStyle = 'rgba(194, 254, 12, 0.03)';
-				ctx.fillRect(0, glitchY, w, 1);
+				ctx.fillStyle = 'rgba(194, 254, 12, 0.07)';
+				ctx.fillRect(0, glitchY, w, 2);
 			}
 
 			t += speed;


### PR DESCRIPTION
## Changes

1. **rAF idle pause** — draw loop stops when no audio/migration/transition active. `startAnim()` restarts on phase/playingNotes changes. Zero CPU at rest.

2. **Light mode** — canvas-frame uses `var(--base)`, draw loop detects theme via `data-theme` attribute at mount.

3. **Remove vignette** — saves `createRadialGradient` + `fillRect` per frame. Cleaner look in contained viewport.

## QA Checklist
- [ ] Light mode: canvas background matches page theme
- [ ] Idle: open quiz, don't play — CPU near zero
- [ ] Play audio: draw loop restarts, particles animate
- [ ] After settle: CPU drops back to near zero
- [ ] No regressions on quiz flow