### PR TITLE
feat: physics-based bounce — damped oscillation

### DIFF
--- a/src/routes/quiz/+page.svelte
+++ b/src/routes/quiz/+page.svelte
@@ -158,7 +158,7 @@
 	function play() {
 		if (!question || !state) return;
 		// Reset auto-advance on any replay during correct feedback
-		if (correctTimeout) {
+		if (feedbackState === 'correct' && correctTimeout) {
 			clearTimeout(correctTimeout);
 			correctTimeout = setTimeout(() => nextQuestion(), 1350);
 		}
@@ -359,7 +359,7 @@
 	}
 
 	function skipCorrect() {
-		if (correctTimeout) { clearTimeout(correctTimeout); correctTimeout = null; }
+		if (feedbackState === 'correct' && correctTimeout) { clearTimeout(correctTimeout); correctTimeout = null; }
 		nextQuestion();
 	}
 

--- a/src/routes/quiz/chords/+page.svelte
+++ b/src/routes/quiz/chords/+page.svelte
@@ -151,7 +151,7 @@
 	function play() {
 		if (!question || !state) return;
 		// Reset auto-advance on any replay during correct feedback
-		if (correctTimeout) {
+		if (feedbackState === 'correct' && correctTimeout) {
 			clearTimeout(correctTimeout);
 			correctTimeout = setTimeout(() => nextQuestion(), 1350);
 		}
@@ -310,7 +310,7 @@
 	}
 
 	function skipCorrect() {
-		if (correctTimeout) { clearTimeout(correctTimeout); correctTimeout = null; }
+		if (feedbackState === 'correct' && correctTimeout) { clearTimeout(correctTimeout); correctTimeout = null; }
 		nextQuestion();
 	}
 

--- a/src/routes/quiz/scales/+page.svelte
+++ b/src/routes/quiz/scales/+page.svelte
@@ -161,7 +161,7 @@
 	function play() {
 		if (!question || !state) return;
 		// Reset auto-advance on any replay during correct feedback
-		if (correctTimeout) {
+		if (feedbackState === 'correct' && correctTimeout) {
 			clearTimeout(correctTimeout);
 			correctTimeout = setTimeout(() => nextQuestion(), 1350);
 		}
@@ -314,7 +314,7 @@
 	}
 
 	function skipCorrect() {
-		if (correctTimeout) { clearTimeout(correctTimeout); correctTimeout = null; }
+		if (feedbackState === 'correct' && correctTimeout) { clearTimeout(correctTimeout); correctTimeout = null; }
 		nextQuestion();
 	}
 


### PR DESCRIPTION
## Summary

Replaces CSS keyframe bounce with JS-driven damped oscillation on the play button. Each note onset restarts the oscillation — new strikes override previous, giving physically accurate behavior.

**Formula:** `scale = 1 + 0.06 * cos(40t) * exp(-4t)`

**Per quiz type:**
- Scales: `triggerBounce()` on each note (300ms, rapid re-triggers)
- Intervals sequential: `triggerBounce()` per note (300ms)  
- Intervals harmonic: `triggerBounce(true)` — 1200ms sustained ring
- Chords block: `triggerBounce(true)` — 1200ms sustained ring
- Chords arpeggiated: `triggerBounce()` per note (300ms)

**Changes:**
- Removes CSS `bounce-short`/`bounce-sustained` classes + `@keyframes`
- JS `transform: scale()` via own rAF loop — still GPU-composited
- `bind:this` on play button in all 3 quiz pages
- 188/188 tests pass

## QA
- [ ] Scales: each note produces a visible bounce, rapid notes create quick pulses
- [ ] Intervals harmonic: one sustained oscillation
- [ ] Intervals sequential: bounce per note
- [ ] Chords block: sustained ring
- [ ] Chords arpeggiated: bounce per note