### PR TITLE
fix: viz pod layout — hug ring, match answers width

### DIFF
--- a/src/components/VizQuizLayout.svelte
+++ b/src/components/VizQuizLayout.svelte
@@ -452,8 +452,10 @@
 <style>
 	.canvas-frame {
 		position: relative;
-		flex: 1;
-		min-height: calc(2.5rem + 1.5rem); /* play button diameter + margin */
+		width: 100%;
+		aspect-ratio: 1;
+		max-height: 50vh;  /* don't dominate the page on tall screens */
+		min-height: 12rem;
 		min-width: 120px;
 		overflow: hidden;
 		border: 1px solid var(--border-heavy);


### PR DESCRIPTION
Replaces flex:1 with aspect-ratio:1 + width:100% + min-height:12rem.

- Pod hugs the Lissajous ring (no dead space below)
- Width matches answer section
- min-height:12rem gives comfortable breathing room
- max-height:50vh caps on tall screens

188/188 tests, build clean.