### PR TITLE
fix: iOS quiz bugs — false Q2 reconnect + banner safe area

### DIFF
--- a/src/routes/quiz/+page.svelte
+++ b/src/routes/quiz/+page.svelte
@@ -182,7 +182,8 @@
 	function play() {
 		if (!question || !state) return;
 		warmUpAudio();
-		// iOS: first call with no gesture → show gate. User tap → skip gate.
+		// iOS: only gate on cold start (no prior user gesture in this session).
+		// Once audioUnlocked, skip the gate — ensureResumed() in playInterval handles resume.
 		if (!audioUnlocked && !isAudioReady() && !needsTap) {
 			needsTap = true;
 			return;
@@ -191,6 +192,7 @@
 			audioUnlocked = true;
 			needsTap = false;
 		}
+		if (!audioUnlocked) audioUnlocked = true;
 		// Reset auto-advance on any replay during correct feedback
 		if (feedbackState === 'correct' && correctTimeout) {
 			clearTimeout(correctTimeout);
@@ -528,7 +530,7 @@
 	}
 	.audio-banner {
 		position: fixed;
-		top: 0;
+		top: env(safe-area-inset-top, 0px);
 		left: 0;
 		right: 0;
 		z-index: 100;

--- a/src/routes/quiz/chords/+page.svelte
+++ b/src/routes/quiz/chords/+page.svelte
@@ -180,6 +180,7 @@
 			audioUnlocked = true;
 			needsTap = false;
 		}
+		if (!audioUnlocked) audioUnlocked = true;
 		// Reset auto-advance on any replay during correct feedback
 		if (feedbackState === 'correct' && correctTimeout) {
 			clearTimeout(correctTimeout);
@@ -519,7 +520,7 @@
 	}
 	.audio-banner {
 		position: fixed;
-		top: 0;
+		top: env(safe-area-inset-top, 0px);
 		left: 0;
 		right: 0;
 		z-index: 100;

--- a/src/routes/quiz/scales/+page.svelte
+++ b/src/routes/quiz/scales/+page.svelte
@@ -190,6 +190,7 @@
 			audioUnlocked = true;
 			needsTap = false;
 		}
+		if (!audioUnlocked) audioUnlocked = true;
 		// Reset auto-advance on any replay during correct feedback
 		if (feedbackState === 'correct' && correctTimeout) {
 			clearTimeout(correctTimeout);
@@ -484,7 +485,7 @@
 	}
 	.audio-banner {
 		position: fixed;
-		top: 0;
+		top: env(safe-area-inset-top, 0px);
 		left: 0;
 		right: 0;
 		z-index: 100;


### PR DESCRIPTION
## Bugs Fixed

### Bug 1: Reconnect banner behind safe area
The 'NEURAL LINK OFFLINE' ticker banner was positioned at `top: 0`, overlapping the Dynamic Island on iOS.
**Fix:** `top: env(safe-area-inset-top, 0px)` on all three quiz pages (intervals, chords, scales).

### Bug 2: Q2 always triggers reconnect (100% repro)
Normal flow: launch → quiz → Q1 plays fine → Q2 shows reconnect banner.
**Root cause:** `scheduleSuspend()` fires between Q1 and Q2 (2s timer), suspending the AudioContext. When Q2's `play()` calls `isAudioReady()`, the context is suspended → falsely triggers the gate.
**Fix:** Once the first user gesture succeeds (`audioUnlocked = true`), keep it set through the session. The gate only triggers on cold start or background resume. `ensureResumed()` inside `playInterval()` handles the actual AudioContext resume.

## Testing
- 188/188 tests pass
- Web build clean