### PR TITLE
feat: desktop responsive layout + Chladni perf optimizations

### DIFF
--- a/src/components/BottomNav.svelte
+++ b/src/components/BottomNav.svelte
@@ -56,4 +56,13 @@
 	}
 	.disabled { cursor: default; }
 	.icon { font-size: 1.25rem; font-family: var(--mono); }
+
+	/* Desktop: nav items more spacious */
+	@media (min-width: 768px) {
+		a, .nav-item {
+			padding: 0.85rem 1.5rem;
+			font-size: 0.65rem;
+		}
+		.icon { font-size: 1.4rem; }
+	}
 </style>

--- a/src/components/ChladniBackground.svelte
+++ b/src/components/ChladniBackground.svelte
@@ -41,12 +41,15 @@
 
 	// ── Constants — matched to lab pages ──
 	const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
-	const PARTICLE_COUNT = isMobile ? 1500 : 3500;
+	const PARTICLE_COUNT = isMobile ? 1000 : 3500;
 	const SETTLE_SPEED_BASE = 0.003;
 	const SETTLE_SPEED_BOOST = 0.025;
 	const JITTER = 0.001;
 	const SHAKE_BASE = 0.02;
 	const SHAKE_AUDIO = 0.05;
+	// 30fps throttle on mobile — skip every other frame
+	const FRAME_SKIP = isMobile ? 2 : 1;
+	const NOISE_INTERVAL = isMobile ? 6 : 3;
 
 	let particles: { x: number; y: number }[] = [];
 	let settleSpeed = SETTLE_SPEED_BASE;
@@ -174,6 +177,13 @@
 		let frameCount = 0;
 
 		function draw() {
+			frameCount++;
+			// 30fps throttle on mobile — skip every other frame
+			if (FRAME_SKIP > 1 && frameCount % FRAME_SKIP !== 0) {
+				animId = requestAnimationFrame(draw);
+				return;
+			}
+
 			const w = canvas.width / dpr;
 			const h = canvas.height / dpr;
 			const cx = w / 2;
@@ -211,8 +221,11 @@
 			const TAU = Math.PI * 2;
 			const modes = currentModes;
 
-			ctx.shadowColor = '#3A2CFF';
-			ctx.shadowBlur = 2;
+			// Skip shadowBlur on mobile — it's the #1 canvas perf hog
+			if (!isMobile) {
+				ctx.shadowColor = '#3A2CFF';
+				ctx.shadowBlur = 2;
+			}
 
 			for (const p of particles) {
 				// Use superposition or single mode (same as lab pages)
@@ -255,24 +268,26 @@
 				ctx.fillRect(sx, sy, pSize, pSize);
 			}
 			ctx.globalAlpha = 1;
-			ctx.shadowBlur = 0;
+			if (!isMobile) ctx.shadowBlur = 0;
 
-			// Noise grain (every 3rd frame, same as lab)
-			if (noiseCanvas && frameCount % 3 === 0) {
+			// Noise grain (throttled on mobile)
+			if (noiseCanvas && frameCount % NOISE_INTERVAL === 0) {
 				refreshNoise(Math.ceil(w), Math.ceil(h));
 				ctx.globalAlpha = 0.5;
 				ctx.drawImage(noiseCanvas, 0, 0, w, h);
 				ctx.globalAlpha = 1;
 			}
 
-			// Vignette (same as lab)
-			const vigR = Math.min(cx, cy) * 0.5;
-			const vigGrad = ctx.createRadialGradient(cx, cy, vigR, cx, cy, Math.max(w, h) * 0.72);
-			vigGrad.addColorStop(0, 'rgba(0,0,0,0)');
-			vigGrad.addColorStop(0.7, 'rgba(0,0,0,0.15)');
-			vigGrad.addColorStop(1, 'rgba(0,0,0,0.55)');
-			ctx.fillStyle = vigGrad;
-			ctx.fillRect(0, 0, w, h);
+			// Vignette — skip on mobile (radialGradient per frame is expensive)
+			if (!isMobile) {
+				const vigR = Math.min(cx, cy) * 0.5;
+				const vigGrad = ctx.createRadialGradient(cx, cy, vigR, cx, cy, Math.max(w, h) * 0.72);
+				vigGrad.addColorStop(0, 'rgba(0,0,0,0)');
+				vigGrad.addColorStop(0.7, 'rgba(0,0,0,0.15)');
+				vigGrad.addColorStop(1, 'rgba(0,0,0,0.55)');
+				ctx.fillStyle = vigGrad;
+				ctx.fillRect(0, 0, w, h);
+			}
 
 			// Scanline flicker (same as lab)
 			if (frameCount % 120 < 2) {
@@ -281,7 +296,6 @@
 				ctx.fillRect(0, glitchY, w, 1);
 			}
 
-			frameCount++;
 			animId = requestAnimationFrame(draw);
 		}
 

--- a/src/components/ChladniCanvas.svelte
+++ b/src/components/ChladniCanvas.svelte
@@ -8,9 +8,10 @@
 	let animId: number;
 
 	const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
-	const PARTICLE_COUNT = isMobile ? 1500 : 3000;
+	const PARTICLE_COUNT = isMobile ? 1000 : 3000;
 	const SETTLE_SPEED = 0.004;    // how fast particles drift to nodal lines
 	const JITTER = 0.001;          // random noise to keep things alive
+	const FRAME_SKIP = isMobile ? 2 : 1;
 
 	// Chladni equation: cos(n*x)*cos(m*y) - cos(m*x)*cos(n*y)
 	// Nodal lines are where this equals zero
@@ -71,7 +72,15 @@
 		window.addEventListener('resize', resize);
 		initParticles();
 
+		let frameCount = 0;
+
 		function draw() {
+			frameCount++;
+			if (FRAME_SKIP > 1 && frameCount % FRAME_SKIP !== 0) {
+				animId = requestAnimationFrame(draw);
+				return;
+			}
+
 			const w = canvas.width / dpr;
 			const h = canvas.height / dpr;
 			const n = currentN;
@@ -83,8 +92,10 @@
 
 			// Update + draw particles
 			ctx.fillStyle = '#C2FE0C';
-			ctx.shadowColor = '#C2FE0C';
-			ctx.shadowBlur = 2;
+			if (!isMobile) {
+				ctx.shadowColor = '#C2FE0C';
+				ctx.shadowBlur = 2;
+			}
 
 			for (const p of particles) {
 				// Compute gradient and drift toward nodal line
@@ -119,7 +130,7 @@
 			}
 
 			ctx.globalAlpha = 1;
-			ctx.shadowBlur = 0;
+			if (!isMobile) ctx.shadowBlur = 0;
 
 			animId = requestAnimationFrame(draw);
 		}

--- a/src/components/VizQuizLayout.svelte
+++ b/src/components/VizQuizLayout.svelte
@@ -114,12 +114,15 @@
 	// ── Chladni constants (from lab) ──
 	const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
 	const sv = JSON.parse(localStorage.getItem('ear-trainer-state') || '{}')?.settings?.superchargeViz;
-	const PARTICLE_COUNT = isMobile ? (sv ? 1500 : 0) : (sv === false ? 0 : 3500);
+	const PARTICLE_COUNT = isMobile ? (sv ? 1000 : 0) : (sv === false ? 0 : 3500);
 	const SETTLE_SPEED_BASE = 0.003;
 	const SETTLE_SPEED_BOOST = 0.025;
 	const JITTER = 0.001;
 	const SHAKE_BASE = 0.02;
 	const SHAKE_AUDIO = 0.05;
+	// 30fps throttle on mobile — skip every other frame
+	const FRAME_SKIP = isMobile ? 2 : 1;
+	const NOISE_INTERVAL = isMobile ? 6 : 3;
 	let particles: { x: number; y: number }[] = [];
 	let settleSpeed = SETTLE_SPEED_BASE;
 	let migrateTimer = 0;
@@ -274,6 +277,13 @@
 		const clearColor = parsedRgb.replace('rgb(', 'rgba(').replace(')', ', 0.14)');
 
 		function draw() {
+			frameCount++;
+			// 30fps throttle on mobile — skip every other frame
+			if (FRAME_SKIP > 1 && frameCount % FRAME_SKIP !== 0) {
+				animId = requestAnimationFrame(draw);
+				return;
+			}
+
 			const w = canvas.width / dpr;
 			const h = canvas.height / dpr;
 			const cx = w / 2;
@@ -345,8 +355,10 @@
 			const currentShake = SHAKE_BASE + amp * SHAKE_AUDIO;
 			const migrating = migrateTimer > 0;
 
-			ctx.shadowColor = '#3A2CFF';
-			ctx.shadowBlur = 2;
+			if (!isMobile) {
+				ctx.shadowColor = '#3A2CFF';
+				ctx.shadowBlur = 2;
+			}
 
 			for (const p of particles) {
 				if (chladniActive) {
@@ -384,13 +396,13 @@
 				ctx.fillRect(sx, sy, migrating ? 1.6 : 1.2, migrating ? 1.6 : 1.2);
 			}
 			ctx.globalAlpha = 1;
-			ctx.shadowBlur = 0;
+			if (!isMobile) ctx.shadowBlur = 0;
 			} // end particles.length > 0
 
 			// Ring + dot now CSS on .play-tap (removed canvas Lissajous)
 
 			// ── NOISE GRAIN ──
-			if (noiseCanvas && frameCount % 3 === 0) {
+			if (noiseCanvas && frameCount % NOISE_INTERVAL === 0) {
 				refreshNoise(Math.ceil(w), Math.ceil(h));
 				ctx.globalAlpha = 0.5;
 				ctx.drawImage(noiseCanvas, 0, 0, w, h);
@@ -406,7 +418,6 @@
 			}
 
 			t += speed;
-			frameCount++;
 			// Pause when nothing needs animation
 			const needsAnim = chladniDriftEnabled || migrateTimer > 0 || transitionActive;
 			if (needsAnim) {
@@ -491,4 +502,11 @@
 	.frame-corner.tr { top: -1px; right: -1px; border-width: 2px 2px 0 0; }
 	.frame-corner.bl { bottom: -1px; left: -1px; border-width: 0 0 2px 2px; }
 	.frame-corner.br { bottom: -1px; right: -1px; border-width: 0 2px 2px 0; }
+
+	/* Desktop: canvas can be taller in two-column layout */
+	@media (min-width: 768px) {
+		.canvas-frame {
+			max-height: 65vh;
+		}
+	}
 </style>

--- a/src/lib/viz-config.ts
+++ b/src/lib/viz-config.ts
@@ -11,7 +11,7 @@ function isMobile(): boolean {
 
 export const CHLADNI_CONFIG = {
 	/** Number of particles (scaled for mobile) */
-	get particleCount() { return isMobile() ? 1500 : 3500; },
+	get particleCount() { return isMobile() ? 1000 : 3500; },
 
 	/** Base particle settle speed (drift toward nodal lines) */
 	settleSpeedBase: 0.003,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -115,4 +115,14 @@
 		border: none;
 		cursor: pointer;
 	}
+
+	/* Desktop: wider container, more breathing room */
+	@media (min-width: 768px) {
+		.app {
+			max-width: 960px;
+		}
+		.content {
+			padding: 2rem 2.5rem;
+		}
+	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -345,4 +345,14 @@
 		z-index: 1;
 		position: relative;
 	}
+
+	/* Desktop: bigger radar zone + GO button */
+	@media (min-width: 768px) {
+		.title { font-size: 8rem; }
+		.title-accent { font-size: 4.5rem; }
+		.center-area { width: 440px; }
+		.radar-zone { width: 380px; height: 380px; }
+		.start-btn { width: 220px; height: 220px; }
+		.btn-text { font-size: 2.5rem; }
+	}
 </style>

--- a/src/routes/progress/+page.svelte
+++ b/src/routes/progress/+page.svelte
@@ -340,4 +340,15 @@
 		z-index: 1;
 		position: relative;
 	}
+
+	/* Desktop: two-column card grid */
+	@media (min-width: 768px) {
+		.progress-page { max-width: 800px; margin: 0 auto; }
+		.interval-list {
+			display: grid;
+			grid-template-columns: repeat(2, 1fr);
+			gap: 0.75rem;
+		}
+		.heading { font-size: 3.5rem; }
+	}
 </style>

--- a/src/routes/quiz/+page.svelte
+++ b/src/routes/quiz/+page.svelte
@@ -484,7 +484,9 @@
 	</div>
 
 	{#if question}
-		<VizQuizLayout
+		<div class="quiz-body">
+			<div class="quiz-viz">
+				<VizQuizLayout
 			superchargeViz={state?.settings?.superchargeViz}
 			mode="interval"
 			phase={vizPhase}
@@ -499,9 +501,10 @@
 					{displayText}
 				</span>
 			</button>
-		</VizQuizLayout>
+			</VizQuizLayout>
+			</div>
 
-		<div class="answer-area" class:hidden={!hasPlayed && !needsTap}>
+			<div class="answer-area" class:hidden={!hasPlayed && !needsTap}>
 			<AnswerGrid
 				choices={needsTap ? question.choices.map(c => ({ ...c, label: 'NA', name: 'UNAVAILABLE' })) : question.choices}
 				onselect={selectAnswer}
@@ -513,6 +516,7 @@
 				countdownPct={inResultMode ? countdownPct : -1}
 				onWrongClick={inResultMode ? replayInResult : null}
 			/>
+		</div>
 		</div>
 	{/if}
 </div>
@@ -775,4 +779,50 @@
 		border-color: var(--accent);
 	}
 	.action-btn.primary:active { opacity: 0.85; }
+
+	/* Desktop: two-column quiz layout */
+	@media (min-width: 768px) {
+		.quiz { gap: 0.75rem; }
+		.quiz-body {
+			display: flex;
+			flex-direction: row;
+			gap: 2rem;
+			width: 100%;
+			flex: 1;
+			min-height: 0;
+			align-items: stretch;
+		}
+		.quiz-viz {
+			flex: 1 1 55%;
+			min-width: 0;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}
+		.quiz-viz :global(.canvas-frame) {
+			max-height: 100%;
+			aspect-ratio: 1;
+		}
+		.answer-area {
+			flex: 1 1 40%;
+			min-width: 0;
+			margin-top: 0;
+			display: flex;
+			align-items: center;
+			width: 100%;
+		}
+		.answer-area :global(.answer-grid) {
+			width: 100%;
+		}
+		.heading { font-size: 3.5rem; }
+		.play-tap {
+			width: min(30vw, 180px);
+			height: min(30vw, 180px);
+		}
+		.q-text { font-size: 1.8rem; }
+		.summary {
+			max-width: 600px;
+			margin: 0 auto;
+		}
+	}
 </style>

--- a/src/routes/quiz/chords/+page.svelte
+++ b/src/routes/quiz/chords/+page.svelte
@@ -474,24 +474,27 @@
 	</div>
 
 	{#if question}
-		<VizQuizLayout
-			superchargeViz={state?.settings?.superchargeViz}
-			mode="chord"
-			phase={vizPhase}
-			chordIntervals={question.chord.intervals}
-			countdownPct={hasPlayed && inResultMode ? countdownPct : -1}
-			ontransitionend={handleTransitionEnd}
-			{playingNotes}
-		>
-			<button bind:this={playBtnEl} class="play-tap" class:feedback-correct={feedbackState === 'correct'} class:feedback-wrong={feedbackState === 'wrong'} onclick={hasPlayed && inResultMode ? replayInResult : play}>
-				<div class="orbit-track"><div class="orbit-dot"></div></div>
-				<span class="q-text" class:feedback-correct={feedbackState === 'correct'} class:feedback-wrong={feedbackState === 'wrong'} class:glitch-text={showGlitch}>
-					{displayText}
-				</span>
-			</button>
-		</VizQuizLayout>
+		<div class="quiz-body">
+			<div class="quiz-viz">
+				<VizQuizLayout
+					superchargeViz={state?.settings?.superchargeViz}
+					mode="chord"
+					phase={vizPhase}
+					chordIntervals={question.chord.intervals}
+					countdownPct={hasPlayed && inResultMode ? countdownPct : -1}
+					ontransitionend={handleTransitionEnd}
+					{playingNotes}
+				>
+					<button bind:this={playBtnEl} class="play-tap" class:feedback-correct={feedbackState === 'correct'} class:feedback-wrong={feedbackState === 'wrong'} onclick={hasPlayed && inResultMode ? replayInResult : play}>
+						<div class="orbit-track"><div class="orbit-dot"></div></div>
+						<span class="q-text" class:feedback-correct={feedbackState === 'correct'} class:feedback-wrong={feedbackState === 'wrong'} class:glitch-text={showGlitch}>
+							{displayText}
+						</span>
+					</button>
+				</VizQuizLayout>
+			</div>
 
-		<div class="answer-area" class:hidden={!hasPlayed && !needsTap}>
+			<div class="answer-area" class:hidden={!hasPlayed && !needsTap}>
 			<AnswerGrid
 				choices={needsTap ? question.choices.map(c => ({ ...c, label: 'NA', name: 'UNAVAILABLE' })) : question.choices}
 				onselect={selectAnswer}
@@ -503,6 +506,7 @@
 				countdownPct={inResultMode ? countdownPct : -1}
 				onWrongClick={inResultMode ? replayInResult : null}
 			/>
+		</div>
 		</div>
 	{/if}
 </div>
@@ -789,4 +793,45 @@
 		border-color: var(--accent);
 	}
 	.action-btn.primary:active { opacity: 0.85; }
+
+	/* Desktop: two-column quiz layout */
+	@media (min-width: 768px) {
+		.quiz { gap: 0.75rem; }
+		.quiz-body {
+			display: flex;
+			flex-direction: row;
+			gap: 2rem;
+			width: 100%;
+			flex: 1;
+			min-height: 0;
+			align-items: stretch;
+		}
+		.quiz-viz {
+			flex: 1 1 55%;
+			min-width: 0;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}
+		.quiz-viz :global(.canvas-frame) {
+			max-height: 100%;
+			aspect-ratio: 1;
+		}
+		.answer-area {
+			flex: 1 1 40%;
+			min-width: 0;
+			margin-top: 0;
+			display: flex;
+			align-items: center;
+		}
+		.heading { font-size: 3.5rem; }
+		.play-tap {
+			width: min(35vw, 200px);
+			height: min(35vw, 200px);
+		}
+		.summary {
+			max-width: 600px;
+			margin: 0 auto;
+		}
+	}
 </style>

--- a/src/routes/quiz/scales/+page.svelte
+++ b/src/routes/quiz/scales/+page.svelte
@@ -439,35 +439,39 @@
 	</div>
 
 	{#if question}
-		<VizQuizLayout
-			superchargeViz={state?.settings?.superchargeViz}
-			mode="scale"
-			phase={vizPhase}
-			scaleIntervals={question.scale.intervals}
-			countdownPct={hasPlayed && inResultMode ? countdownPct : -1}
-			ontransitionend={handleTransitionEnd}
-			{playingNotes}
-		>
-			<button bind:this={playBtnEl} class="play-tap" class:feedback-correct={feedbackState === 'correct'} class:feedback-wrong={feedbackState === 'wrong'} onclick={hasPlayed && inResultMode ? replayInResult : play}>
-				<div class="orbit-track"><div class="orbit-dot"></div></div>
-				<span class="q-text" class:feedback-correct={feedbackState === 'correct'} class:feedback-wrong={feedbackState === 'wrong'} class:glitch-text={showGlitch}>
-					{displayText}
-				</span>
-			</button>
-		</VizQuizLayout>
+		<div class="quiz-body">
+			<div class="quiz-viz">
+				<VizQuizLayout
+					superchargeViz={state?.settings?.superchargeViz}
+					mode="scale"
+					phase={vizPhase}
+					scaleIntervals={question.scale.intervals}
+					countdownPct={hasPlayed && inResultMode ? countdownPct : -1}
+					ontransitionend={handleTransitionEnd}
+					{playingNotes}
+				>
+					<button bind:this={playBtnEl} class="play-tap" class:feedback-correct={feedbackState === 'correct'} class:feedback-wrong={feedbackState === 'wrong'} onclick={hasPlayed && inResultMode ? replayInResult : play}>
+						<div class="orbit-track"><div class="orbit-dot"></div></div>
+						<span class="q-text" class:feedback-correct={feedbackState === 'correct'} class:feedback-wrong={feedbackState === 'wrong'} class:glitch-text={showGlitch}>
+							{displayText}
+						</span>
+					</button>
+				</VizQuizLayout>
+			</div>
 
-		<div class="answer-area" class:hidden={!hasPlayed && !needsTap}>
-			<AnswerGrid
-				choices={needsTap ? question.choices.map(c => ({ ...c, label: 'NA', name: 'UNAVAILABLE' })) : question.choices}
-				onselect={selectAnswer}
-				disabled={needsTap || !hasPlayed || !!selectedId}
-				offline={needsTap}
-				correctId={selectedId ? question.scale.id : null}
-				{selectedId}
-				onCorrectClick={selectedId ? (inResultMode ? nextQuestion : skipCorrect) : null}
-				countdownPct={inResultMode ? countdownPct : -1}
-				onWrongClick={inResultMode ? replayInResult : null}
-			/>
+			<div class="answer-area" class:hidden={!hasPlayed && !needsTap}>
+				<AnswerGrid
+					choices={needsTap ? question.choices.map(c => ({ ...c, label: 'NA', name: 'UNAVAILABLE' })) : question.choices}
+					onselect={selectAnswer}
+					disabled={needsTap || !hasPlayed || !!selectedId}
+					offline={needsTap}
+					correctId={selectedId ? question.scale.id : null}
+					{selectedId}
+					onCorrectClick={selectedId ? (inResultMode ? nextQuestion : skipCorrect) : null}
+					countdownPct={inResultMode ? countdownPct : -1}
+					onWrongClick={inResultMode ? replayInResult : null}
+				/>
+			</div>
 		</div>
 	{/if}
 </div>
@@ -713,4 +717,45 @@
 		border-color: var(--accent);
 	}
 	.action-btn.primary:active { opacity: 0.85; }
+
+	/* Desktop: two-column quiz layout */
+	@media (min-width: 768px) {
+		.quiz { gap: 0.75rem; }
+		.quiz-body {
+			display: flex;
+			flex-direction: row;
+			gap: 2rem;
+			width: 100%;
+			flex: 1;
+			min-height: 0;
+			align-items: stretch;
+		}
+		.quiz-viz {
+			flex: 1 1 55%;
+			min-width: 0;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}
+		.quiz-viz :global(.canvas-frame) {
+			max-height: 100%;
+			aspect-ratio: 1;
+		}
+		.answer-area {
+			flex: 1 1 40%;
+			min-width: 0;
+			margin-top: 0;
+			display: flex;
+			align-items: center;
+		}
+		.heading { font-size: 3.5rem; }
+		.play-tap {
+			width: min(35vw, 200px);
+			height: min(35vw, 200px);
+		}
+		.summary {
+			max-width: 600px;
+			margin: 0 auto;
+		}
+	}
 </style>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -673,4 +673,15 @@
 		border-top: 1px solid var(--border);
 	}
 	.credits-accent { color: var(--marathon-blue); }
+
+	/* Desktop: constrained width, larger type */
+	@media (min-width: 768px) {
+		.settings-page { max-width: 600px; margin: 0 auto; }
+		.heading { font-size: 3.5rem; }
+		.credits-grid {
+			display: grid;
+			grid-template-columns: repeat(2, 1fr);
+			gap: 0.5rem;
+		}
+	}
 </style>


### PR DESCRIPTION
## Desktop Layout (≥768px)
- **Shell**: max-width 480→960px, increased padding
- **Home**: larger title (8rem), 380px radar zone, 220px GO button
- **Quiz**: two-column layout — viz canvas (55%) | answer grid (45%)
- **Progress**: 2-column card grid for intervals/chords/scales
- **Settings**: centered at 600px max-width, 2-col credits
- **BottomNav**: larger touch targets on desktop
- **VizQuizLayout**: canvas max-height bumped to 65vh on desktop

## Chladni Performance (mobile)
- **30fps cap** via frame-skip (skip every other rAF frame)
- **`shadowBlur` removed** on mobile — #1 canvas performance hog
- **Particles reduced** 1500→1000 on mobile (supercharged mode)
- **Noise texture throttled** — every 6th frame on mobile (was 3rd)
- **Vignette skipped** on mobile — radialGradient per frame is expensive
- Applied across ChladniBackground, ChladniCanvas, VizQuizLayout

## Testing Notes
- Desktop: all pages (home, quiz, progress, settings) verified at 1280px
- Mobile: verified at 375px — layout unchanged from main
- Build passes clean (`npm run build` success)
- No new dependencies

Closes S4 desktop sprint. @palm-bot for QA.