### PR TITLE
ci: per-PR preview deploys on GitHub Pages

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,40 @@
+name: PR Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - if: github.event.action != 'closed'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - if: github.event.action != 'closed'
+        run: npm ci
+
+      - if: github.event.action != 'closed'
+        run: npm run build
+        env:
+          BASE_PATH: '/ear-trainer/pr/${{ github.event.number }}'
+
+      - uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: build/
+          preview-branch: gh-pages
+          umbrella-dir: pr
+          action: auto

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,7 +3,6 @@ name: Deploy Staging to GitHub Pages
 on:
   push:
     branches:
-      - feat/visualization
       - main
 
 permissions:
@@ -29,6 +28,15 @@ jobs:
       - run: npm run build
         env:
           BASE_PATH: '/ear-trainer'
+
+      # Preserve PR preview directories during staging deploy
+      - name: Fetch existing PR previews
+        run: |
+          git fetch origin gh-pages --depth=1 || true
+          if git show origin/gh-pages:pr 2>/dev/null; then
+            git checkout origin/gh-pages -- pr/
+            cp -r pr build/pr
+          fi
 
       - uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
## What
Per-PR preview deployments so Mike can test any PR from his phone without dev access.

**New:** `.github/workflows/pr-preview.yml`
- On PR open/sync: builds with `BASE_PATH=/ear-trainer/pr/<number>`, deploys to gh-pages `pr/` subdirectory
- On PR close/merge: cleans up the preview directory
- Uses `rossjrw/pr-preview-action@v1`
- Preview URL posted as a PR comment automatically

**Updated:** `.github/workflows/staging.yml`
- Preserves `pr/` directory during main branch deploys (fetches from gh-pages before publish)
- Removed stale `feat/visualization` branch trigger

## Preview URLs
`mengmikeli.github.io/ear-trainer/pr/<number>/`

## Testing
This PR will self-test — once CI runs, it should deploy its own preview (which will be mostly the CI files + current main code).