### PR TITLE
feat: Progress page Modes tab (Fixes #54)

### DIFF
--- a/src/components/ModeCard.svelte
+++ b/src/components/ModeCard.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+	import type { ModeState } from '$lib/types';
+	import type { ModeDef } from '$lib/modes';
+
+	interface Props {
+		def: ModeDef;
+		state: ModeState;
+		ontoggle?: (id: string) => void;
+		onplay?: (id: string) => void;
+		playing?: boolean;
+	}
+	let { def, state: mstate, ontoggle, onplay, playing = false }: Props = $props();
+
+	const accuracy = $derived(mstate.attempts > 0 ? Math.round((mstate.correct / mstate.attempts) * 100) : 0);
+
+	let pendingFlip = $state(false);
+	let pressed = $state(false);
+	const isOff = $derived(pressed || pendingFlip ? mstate.enabled : !mstate.enabled);
+
+	function handleToggle() {
+		if (!ontoggle) return;
+		pendingFlip = true;
+		pressed = false;
+		requestAnimationFrame(() => {
+			ontoggle(def.id);
+			pendingFlip = false;
+		});
+	}
+</script>
+
+<div class="card" class:locked={!mstate.unlocked} class:disabled={mstate.unlocked && !mstate.enabled} class:playing
+	onclick={() => { if (mstate.unlocked && onplay) onplay(def.id); }}
+	role={mstate.unlocked && onplay ? 'button' : undefined}
+	tabindex={mstate.unlocked && onplay ? 0 : undefined}
+>
+	<div class="card-fill" style="width: {mstate.unlocked && mstate.enabled ? accuracy : 0}%"></div>
+	<div class="card-content">
+		<div class="id">
+			{mstate.unlocked ? def.label : 'NA'}
+		</div>
+		<div class="info">
+			<div class="name">{def.name}</div>
+			{#if mstate.unlocked && mstate.attempts === 0}
+				<div class="stats new">NEW</div>
+			{:else if mstate.unlocked}
+				<div class="stats"><span class="stat-tag">ACC</span><span class="stat-value">{accuracy}%</span><span class="stat-tag">Q</span><span class="stat-value">{mstate.attempts}</span></div>
+			{:else}
+				<div class="stats"><span class="tier-tag">T{def.tier}</span> LOCKED</div>
+			{/if}
+		</div>
+		{#if mstate.unlocked && ontoggle}
+			<button class="toggle" class:toggle-off={isOff}
+				onpointerdown={(e) => { e.stopPropagation(); pressed = true; }}
+				onpointerup={() => pressed = false}
+				onpointerleave={() => pressed = false}
+				onclick={(e) => { e.stopPropagation(); handleToggle(); }}>
+				{isOff ? 'OFF' : 'ON'}
+			</button>
+		{:else if mstate.unlocked}
+			<div class="acc-value">{mstate.attempts > 0 ? `${accuracy}%` : '—'}</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.card {
+		position: relative; overflow: hidden;
+		background: var(--surface);
+		border-left: 3px solid var(--accent);
+		cursor: pointer;
+		transition: border-left-color 0.15s;
+	}
+	.card.playing { border-left-color: var(--marathon-blue); }
+	.card-fill {
+		position: absolute; top: 0; left: 0; bottom: 0;
+		background: var(--accent); opacity: 0.12;
+		transition: width 0.35s ease-out;
+	}
+	.card-content {
+		position: relative; z-index: 1;
+		display: grid; grid-template-columns: 5.5rem 1fr auto;
+		align-items: center; gap: 0.75rem; padding: 0.85rem;
+	}
+	.locked { opacity: 0.4; border-left-color: var(--hot); }
+	.disabled { opacity: 0.55; border-left-color: var(--hot); transition: opacity 0.3s ease 0.3s; }
+	.disabled .id { color: var(--hot); }
+	.disabled .name { color: var(--text-secondary); }
+	.disabled .toggle { opacity: calc(1 / 0.55); }
+	.id {
+		font-size: 2rem; font-weight: 900;
+		font-family: 'BPdots', 'JetBrains Mono', monospace; text-align: center;
+		color: var(--accent); line-height: 1;
+		transform: translateY(-5px);
+	}
+	.locked .id { color: var(--hot); font-size: 2rem; }
+	.name { font-weight: 400; font-size: 0.85rem; letter-spacing: 0.02em; font-family: var(--font-display); }
+	.stats { font-size: 0.4rem; color: var(--text-secondary); font-weight: 600; font-family: var(--mono); display: flex; align-items: center; gap: 2px; opacity: 0.7; }
+	.stat-tag {
+		display: inline-flex; align-items: center;
+		border: 1px solid var(--accent); padding: 0 4px;
+		font-size: 0.35rem; font-family: var(--mono);
+		color: var(--accent); font-weight: 900;
+		white-space: nowrap; line-height: 1.6;
+	}
+	.stat-value {
+		display: inline-flex; align-items: center;
+		font-size: 0.35rem; font-family: var(--mono);
+		color: var(--text-primary); font-weight: 900;
+		padding: 0 6px 0 3px; white-space: nowrap; line-height: 1.6;
+	}
+	.new { color: var(--accent); font-weight: 900; letter-spacing: 0.2em; }
+	.tier-tag {
+		display: inline-flex; align-items: center;
+		border: 1px solid var(--hot); padding: 0 4px;
+		font-size: 0.35rem; font-family: var(--mono);
+		color: var(--hot); margin-right: 4px;
+	}
+	.acc-value {
+		font-size: 0.7rem; font-weight: 900;
+		font-family: var(--mono); color: var(--text-primary);
+		letter-spacing: -0.02em;
+	}
+	.toggle {
+		font-family: var(--mono); font-size: 0.45rem; font-weight: 900;
+		letter-spacing: 0.05em; padding: 0.3rem 0.5rem;
+		border: 1px solid var(--marathon-blue); background: var(--surface);
+		color: var(--marathon-blue); cursor: pointer;
+		transition: color 0.15s, border-color 0.15s, background 0.15s;
+		display: inline-flex; align-items: center; justify-content: center;
+		line-height: 1;
+		width: 2.8rem; height: 1.4rem;
+		box-sizing: border-box;
+	}
+	.toggle-off { border-color: var(--hot); background: #ED174F10; color: var(--hot); }
+</style>

--- a/src/routes/progress/+page.svelte
+++ b/src/routes/progress/+page.svelte
@@ -4,11 +4,13 @@
 	import { INTERVALS } from '$lib/intervals';
 	import { CHORDS } from '$lib/chords';
 	import { SCALES } from '$lib/scales';
+	import { MODES } from '$lib/modes';
 	import { playInterval, playChord, playScale } from '$lib/audio';
 	import { isModeMastered } from '$lib/mastery';
 	import IntervalCard from '../../components/IntervalCard.svelte';
 	import ChordCard from '../../components/ChordCard.svelte';
 	import ScaleCard from '../../components/ScaleCard.svelte';
+	import ModeCard from '../../components/ModeCard.svelte';
 	import TelemetryBar from '../../components/TelemetryBar.svelte';
 	import type { UserState, PlayMode, ChordVoicing } from '$lib/types';
 
@@ -17,7 +19,7 @@
 	let activeTab: PlayMode | null = $state(null);
 	let chordVoicingTab: ChordVoicing | null = $state(null);
 	let playingId: string | null = $state(null);
-	let contentView: 'intervals' | 'chords' | 'scales' = $state('intervals');
+	let contentView: 'intervals' | 'chords' | 'scales' | 'modes' = $state('intervals');
 
 	const modes: PlayMode[] = ['ascending', 'descending', 'harmonic'];
 
@@ -61,6 +63,13 @@
 			if (mastered >= 1) bronzeCount++;
 		}
 		return bronzeCount >= 3;
+	});
+
+	const modesUnlocked = $derived(() => {
+		if (!state) return false;
+		if (state.settings.devMode) return true;
+		// Modes unlock when scales are unlocked (same gate)
+		return scalesUnlocked();
 	});
 
 	onMount(() => {
@@ -148,6 +157,33 @@
 		setTimeout(() => { playingId = null; }, dur);
 	}
 
+	function toggleMode(id: string) {
+		if (!state || !state.modes) return;
+		const m = state.modes[id];
+		if (!m || !m.unlocked) return;
+		if (m.enabled) {
+			const enabledCount = Object.values(state.modes).filter(md => md.unlocked && md.enabled).length;
+			if (enabledCount <= 2) {
+				minWarning = true;
+				setTimeout(() => { minWarning = false; }, 2000);
+				return;
+			}
+		}
+		state.modes[id].enabled = !m.enabled;
+		state = { ...state };
+		saveState(state);
+	}
+
+	function playModePreview(id: string) {
+		if (!state || playingId) return;
+		const def = MODES.find(d => d.id === id);
+		if (!def) return;
+		playingId = id;
+		playScale(60, def.intervals, state.settings.toneType, 150);
+		const dur = def.intervals.length * 150 + 200;
+		setTimeout(() => { playingId = null; }, dur);
+	}
+
 	const telemetrySegments = $derived(() => {
 		if (!state) return [];
 		if (contentView === 'chords') {
@@ -190,6 +226,20 @@
 				{ label: 'ACC', value: acc + '%' },
 			];
 		}
+		if (contentView === 'modes') {
+			if (!state.modes) return [];
+			let attempts = 0, correct = 0;
+			for (const m of Object.values(state.modes)) {
+				if (!m.unlocked) continue;
+				attempts += m.attempts;
+				correct += m.correct;
+			}
+			const acc = attempts > 0 ? Math.round((correct / attempts) * 100) : 0;
+			return [
+				{ label: 'Q', value: attempts },
+				{ label: 'ACC', value: acc + '%' },
+			];
+		}
 		if (!activeTab) {
 			return [
 				{ label: 'SES', value: state.stats.totalSessions },
@@ -215,7 +265,7 @@
 <div class="progress-page">
 	<h2 class="heading">PROGRESS</h2>
 
-	{#if chordsUnlocked() || scalesUnlocked()}
+	{#if chordsUnlocked() || scalesUnlocked() || modesUnlocked()}
 		<div class="content-toggle">
 			<button class="ct-btn" class:active={contentView === 'intervals'} onclick={() => contentView = 'intervals'}>INTERVALS</button>
 			{#if chordsUnlocked()}
@@ -223,6 +273,9 @@
 			{/if}
 			{#if scalesUnlocked()}
 			<button class="ct-btn" class:active={contentView === 'scales'} onclick={() => contentView = 'scales'}>SCALES</button>
+			{/if}
+			{#if modesUnlocked()}
+			<button class="ct-btn" class:active={contentView === 'modes'} onclick={() => contentView = 'modes'}>MODES</button>
 			{/if}
 		</div>
 	{/if}
@@ -247,7 +300,7 @@
 		<TelemetryBar segments={telemetrySegments()} />
 
 		{#if minWarning}
-			<div class="min-warn">⚠ MINIMUM {contentView === 'chords' ? '2 CHORDS' : contentView === 'scales' ? '2 SCALES' : '3 INTERVALS'} REQUIRED</div>
+			<div class="min-warn">⚠ MINIMUM {contentView === 'chords' ? '2 CHORDS' : contentView === 'scales' ? '2 SCALES' : contentView === 'modes' ? '2 MODES' : '3 INTERVALS'} REQUIRED</div>
 		{/if}
 
 		{#if contentView === 'intervals'}
@@ -266,6 +319,14 @@
 			<div class="interval-list">
 				{#each SCALES as def}
 					<ScaleCard {def} state={state.scales[def.id]} ontoggle={toggleScale} onplay={playScalePreview} playing={playingId === def.id} />
+				{/each}
+			</div>
+		{:else if contentView === 'modes'}
+			<div class="interval-list">
+				{#each MODES as def}
+					{#if state.modes?.[def.id]}
+						<ModeCard {def} state={state.modes[def.id]} ontoggle={toggleMode} onplay={playModePreview} playing={playingId === def.id} />
+					{/if}
 				{/each}
 			</div>
 		{/if}


### PR DESCRIPTION
Adds MODES tab to the Progress page.

- ModeCard component with toggle/play/stats
- Content toggle button (gated behind modesUnlocked/devMode)
- Telemetry segments for mode stats
- Toggle + play preview functions

Fixes #54. 282/282 tests pass, build clean.