### PR TITLE
fix: hide adaptive UI in non-dev mode (Fixes #52, #53)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -79,7 +79,9 @@
 	});
 
 	const activeContent = $derived(() => {
-		return state?.settings.activeContent ?? 'intervals';
+		const content = state?.settings?.activeContent ?? 'intervals';
+		if (content === 'adaptive' && !state?.settings?.devMode) return 'intervals';
+		return content;
 	});
 
 	function setActiveContent(mode: 'intervals' | 'chords' | 'scales' | 'modes') {
@@ -228,12 +230,14 @@
 	{#if state}
 		<div class="center-area">
 			{#if chordsUnlocked() || scalesUnlocked()}
-				<a href="{base}/quiz/adaptive" class="train-btn" class:glitching={trainGlitching} onclick={handleTrain}>
-					<span class="train-text">{trainText}</span>
-					{#if sessionPreview}
-						<span class="train-preview">{sessionPreview}</span>
-					{/if}
-				</a>
+				{#if state?.settings?.devMode}
+					<a href="{base}/quiz/adaptive" class="train-btn" class:glitching={trainGlitching} onclick={handleTrain}>
+						<span class="train-text">{trainText}</span>
+						{#if sessionPreview}
+							<span class="train-preview">{sessionPreview}</span>
+						{/if}
+					</a>
+				{/if}
 
 				<div class="content-switcher">
 					<button


### PR DESCRIPTION
Fixes #52, fixes #53

**Minimal, safe fix — only 1 file changed:**

**#52:** TRAIN button wrapped in `{#if state?.settings?.devMode}` — hidden for regular users.

**#53:** `activeContent` derived falls back from `'adaptive'` to `'intervals'` when devMode is off. Uses optional chaining throughout.

**What's NOT in this PR:** No quiz page changes. No answerFallback. No state init changes. The reverted PR #57 tried to do too much — this is just the two UI gating fixes.

**Verified:**
- All 7 routes return 200 on clean build
- 282/282 tests pass
- Build clean, no warnings