### PR TITLE
fix: version string v3.6+hash (Fixes #60)

### DIFF
--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,6 +1,9 @@
-export const APP_VERSION = '3.5';
-export const __BUILD_HASH__ = (globalThis as any).__BUILD_HASH__ ?? '';
-export const VERSION_STRING = __BUILD_HASH__ ? `${APP_VERSION} (${__BUILD_HASH__})` : APP_VERSION;
+export const APP_VERSION = '3.6';
+
+// Vite `define` injects this at build time — declared to satisfy TypeScript
+declare const __BUILD_HASH__: string;
+const buildHash = typeof __BUILD_HASH__ !== 'undefined' ? __BUILD_HASH__ : '';
+export const VERSION_STRING = buildHash ? `v${APP_VERSION}+${buildHash}` : `v${APP_VERSION}`;
 
 export interface ReleaseNote {
 	version: string;
@@ -10,6 +13,19 @@ export interface ReleaseNote {
 }
 
 export const RELEASE_NOTES: ReleaseNote[] = [
+	{
+		version: '3.6',
+		date: '2026-03-30',
+		title: 'BUG BASH + MODES',
+		changes: [
+			'Progress page Modes tab with 4 modes across 2 tiers',
+			'Adaptive/Training UI hidden behind dev mode toggle',
+			'Learn cards disabled on cold start — quizzes work immediately',
+			'Version string shows build hash (v3.6+abc1234)',
+			'Light mode Chladni background fix',
+			'Whole Tone + Major Blues scales in lab',
+		],
+	},
 	{
 		version: '3.5',
 		date: '2026-03-30',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
 	import { INTERVALS } from '$lib/intervals';
 	import { CHORDS } from '$lib/chords';
 	import { SCALES } from '$lib/scales';
-	import { APP_VERSION } from '$lib/version';
+	import { VERSION_STRING } from '$lib/version';
 	import { isModeMastered } from '$lib/mastery';
 	import { planSession, type SessionConfig } from '$lib/adaptive';
 	import type { UserState } from '$lib/types';
@@ -222,7 +222,7 @@
 		</div>
 		<div class="version-tag">
 			<span class="hazard-bar"></span>
-			<span class="version">SYS v{APP_VERSION}</span>
+			<span class="version">SYS {VERSION_STRING}</span>
 			<span class="hazard-bar"></span>
 		</div>
 	</header>


### PR DESCRIPTION
Fixes #60

- Bumped to v3.6
- `VERSION_STRING` format: `v3.6+<git-short-hash>` (e.g. `v3.6+bc8a9af`)
- Vite `define` injects `__BUILD_HASH__` at build time via `git rev-parse --short HEAD`
- Home page uses `VERSION_STRING` instead of `APP_VERSION`
- Settings/About shows full version string
- v3.6 release notes added

282/282 tests pass, build clean.