### PR TITLE
feat: all 7 modes with tiered unlock (Fixes #63)

### DIFF
--- a/src/lib/modes.ts
+++ b/src/lib/modes.ts
@@ -1,4 +1,4 @@
-// src/lib/modes.ts — Musical mode definitions (v3.5)
+// src/lib/modes.ts — Musical mode definitions (v3.6)
 
 export interface ModeDef {
 	id: string;
@@ -13,6 +13,31 @@ export interface ModeDef {
 }
 
 export const MODES: ModeDef[] = [
+	// Tier 1 — unlocked by default (the two fundamentals)
+	{
+		id: 'ionian',
+		name: 'Ionian (Major)',
+		label: 'Ion',
+		parent: 'major',
+		degree: 1,
+		intervals: [0, 2, 4, 5, 7, 9, 11, 12],
+		tier: 1,
+		category: 'mode',
+		characteristic: [4, 11],  // M3 + M7 (bright, resolved)
+	},
+	{
+		id: 'aeolian',
+		name: 'Aeolian (Minor)',
+		label: 'Aeo',
+		parent: 'major',
+		degree: 6,
+		intervals: [0, 2, 3, 5, 7, 8, 10, 12],
+		tier: 1,
+		category: 'mode',
+		characteristic: [3, 8, 10],  // m3 + m6 + m7 (dark, melancholy)
+	},
+
+	// Tier 2 — most common after major/minor
 	{
 		id: 'dorian',
 		name: 'Dorian',
@@ -20,9 +45,9 @@ export const MODES: ModeDef[] = [
 		parent: 'major',
 		degree: 2,
 		intervals: [0, 2, 3, 5, 7, 9, 10, 12],
-		tier: 4,
+		tier: 2,
 		category: 'mode',
-		characteristic: [3, 10],  // m3 + m7 (minor feel but bright)
+		characteristic: [3, 10],  // m3 + m7 (minor feel but bright 6th)
 	},
 	{
 		id: 'mixolydian',
@@ -31,9 +56,22 @@ export const MODES: ModeDef[] = [
 		parent: 'major',
 		degree: 5,
 		intervals: [0, 2, 4, 5, 7, 9, 10, 12],
-		tier: 4,
+		tier: 2,
 		category: 'mode',
 		characteristic: [10],  // m7 (major but with flat 7)
+	},
+
+	// Tier 3 — distinctive color modes
+	{
+		id: 'lydian',
+		name: 'Lydian',
+		label: 'Lyd',
+		parent: 'major',
+		degree: 4,
+		intervals: [0, 2, 4, 6, 7, 9, 11, 12],
+		tier: 3,
+		category: 'mode',
+		characteristic: [6],  // aug4/TT (the "dreamy" interval)
 	},
 	{
 		id: 'phrygian',
@@ -42,20 +80,22 @@ export const MODES: ModeDef[] = [
 		parent: 'major',
 		degree: 3,
 		intervals: [0, 1, 3, 5, 7, 8, 10, 12],
-		tier: 4,
+		tier: 3,
 		category: 'mode',
 		characteristic: [1],  // m2 (the "Spanish" flavor)
 	},
+
+	// Tier 4 — the outlier
 	{
-		id: 'lydian',
-		name: 'Lydian',
-		label: 'Lyd',
+		id: 'locrian',
+		name: 'Locrian',
+		label: 'Loc',
 		parent: 'major',
-		degree: 4,
-		intervals: [0, 2, 4, 6, 7, 9, 11, 12],
+		degree: 7,
+		intervals: [0, 1, 3, 5, 6, 8, 10, 12],
 		tier: 4,
 		category: 'mode',
-		characteristic: [6],  // aug4/TT (the "dreamy" interval)
+		characteristic: [1, 6],  // m2 + dim5 (unstable, diminished feel)
 	},
 ];
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -125,10 +125,12 @@ export function createDefaultState(): UserState {
 		scales[def.id] = createDefaultScaleState(def.id, def.tier);
 	}
 
-	// Mode states — all locked initially (unlocked via scale mastery)
+	// Mode states — tier 1 unlocked by default
 	const modes: Record<string, ModeState> = {};
 	for (const def of MODES) {
-		modes[def.id] = createDefaultModeState(def.id);
+		const ms = createDefaultModeState(def.id);
+		ms.unlocked = def.tier === 1;
+		modes[def.id] = ms;
 	}
 
 	return { intervals, chords, scales, modes, settings, stats };
@@ -219,8 +221,13 @@ export function loadState(storage: Storage = localStorage): UserState {
 		// Migrate v3.4 → v3.5: add mode state if missing
 		if (!parsed.modes) {
 			parsed.modes = {};
-			for (const def of MODES) {
-				parsed.modes[def.id] = createDefaultModeState(def.id);
+		}
+		// Ensure all defined modes exist (handles new modes added in updates)
+		for (const def of MODES) {
+			if (!parsed.modes[def.id]) {
+				const ms = createDefaultModeState(def.id);
+				ms.unlocked = def.tier === 1;
+				parsed.modes[def.id] = ms;
 			}
 		}
 

--- a/tests/adaptive.test.ts
+++ b/tests/adaptive.test.ts
@@ -207,6 +207,7 @@ describe('planSession', () => {
 		for (const s of Object.values(state.intervals)) s.unlocked = false;
 		for (const s of Object.values(state.chords)) s.unlocked = false;
 		for (const s of Object.values(state.scales)) s.unlocked = false;
+		if (state.modes) for (const s of Object.values(state.modes)) s.unlocked = false;
 
 		const config: SessionConfig = {
 			length: 20,

--- a/tests/mode-engine.test.ts
+++ b/tests/mode-engine.test.ts
@@ -29,22 +29,24 @@ describe('getEnabledModes', () => {
 		expect(getEnabledModes(undefined)).toEqual([]);
 	});
 
-	it('returns empty when all modes are locked', () => {
+	it('returns tier 1 modes on fresh state (Ionian + Aeolian)', () => {
 		const state = createDefaultState();
-		expect(getEnabledModes(state.modes)).toEqual([]);
+		const enabled = getEnabledModes(state.modes);
+		expect(enabled.length).toBe(2);
+		expect(enabled.map(m => m.id).sort()).toEqual(['aeolian', 'ionian']);
 	});
 
-	it('returns unlocked and enabled modes', () => {
+	it('returns all modes when all unlocked', () => {
 		const state = unlockAllModes(createDefaultState());
 		const enabled = getEnabledModes(state.modes);
-		expect(enabled.length).toBe(4);
+		expect(enabled.length).toBe(7);
 	});
 
 	it('excludes disabled modes', () => {
 		const state = unlockAllModes(createDefaultState());
 		state.modes!['dorian'].enabled = false;
 		const enabled = getEnabledModes(state.modes);
-		expect(enabled.length).toBe(3);
+		expect(enabled.length).toBe(6);
 		expect(enabled.find(m => m.id === 'dorian')).toBeUndefined();
 	});
 });
@@ -54,12 +56,6 @@ describe('generateModeDistractors', () => {
 		const distractors = generateModeDistractors('dorian');
 		expect(distractors.length).toBe(3);
 		expect(distractors.every(d => d.id !== 'dorian')).toBe(true);
-	});
-
-	it('returns all other modes when only 3 exist', () => {
-		// 4 modes total - 1 correct = 3 distractors (exactly fills)
-		const distractors = generateModeDistractors('dorian');
-		expect(distractors.length).toBe(3);
 	});
 
 	it('does not include the correct mode', () => {
@@ -83,6 +79,13 @@ describe('generateModeQuestion', () => {
 		expect(question.replays).toBe(0);
 	});
 
+	it('works on fresh state (tier 1 modes only)', () => {
+		const state = createDefaultState();
+		const question = generateModeQuestion(state);
+		expect(question.mode).toBeDefined();
+		expect(['ionian', 'aeolian']).toContain(question.mode.id);
+	});
+
 	it('includes the correct mode in choices', () => {
 		const state = unlockAllModes(createDefaultState());
 		for (let i = 0; i < 20; i++) {
@@ -94,6 +97,9 @@ describe('generateModeQuestion', () => {
 
 	it('throws when no modes are enabled', () => {
 		const state = createDefaultState();
+		// Disable the two tier 1 modes
+		state.modes!['ionian'].enabled = false;
+		state.modes!['aeolian'].enabled = false;
 		expect(() => generateModeQuestion(state)).toThrow('No enabled modes');
 	});
 
@@ -103,7 +109,7 @@ describe('generateModeQuestion', () => {
 		state.modes!['dorian'].attempts = 100;
 		state.modes!['dorian'].correct = 20; // 20% accuracy
 		// Make others strong
-		for (const id of ['mixolydian', 'phrygian', 'lydian']) {
+		for (const id of ['ionian', 'aeolian', 'mixolydian', 'phrygian', 'lydian', 'locrian']) {
 			state.modes![id].attempts = 100;
 			state.modes![id].correct = 95;
 		}
@@ -113,7 +119,7 @@ describe('generateModeQuestion', () => {
 			const q = generateModeQuestion(state);
 			if (q.mode.id === 'dorian') dorianCount++;
 		}
-		// Dorian should appear more than 25% (uniform) of the time
-		expect(dorianCount).toBeGreaterThan(60);
+		// Dorian should appear more than ~14% (uniform 1/7)
+		expect(dorianCount).toBeGreaterThan(40);
 	});
 });

--- a/tests/modes.test.ts
+++ b/tests/modes.test.ts
@@ -4,14 +4,37 @@ import { describe, it, expect } from 'vitest';
 import { MODES, getModeById, getModesByTier } from '../src/lib/modes';
 
 describe('MODES', () => {
-	it('has 4 modes', () => {
-		expect(MODES.length).toBe(4);
+	it('has 7 modes (all major scale modes)', () => {
+		expect(MODES.length).toBe(7);
 	});
 
-	it('all modes are tier 4', () => {
-		for (const mode of MODES) {
-			expect(mode.tier).toBe(4);
-		}
+	it('has modes across 4 tiers', () => {
+		const tiers = new Set(MODES.map(m => m.tier));
+		expect(tiers).toEqual(new Set([1, 2, 3, 4]));
+	});
+
+	it('tier 1 has Ionian and Aeolian', () => {
+		const t1 = getModesByTier(1);
+		expect(t1.length).toBe(2);
+		expect(t1.map(m => m.id).sort()).toEqual(['aeolian', 'ionian']);
+	});
+
+	it('tier 2 has Dorian and Mixolydian', () => {
+		const t2 = getModesByTier(2);
+		expect(t2.length).toBe(2);
+		expect(t2.map(m => m.id).sort()).toEqual(['dorian', 'mixolydian']);
+	});
+
+	it('tier 3 has Lydian and Phrygian', () => {
+		const t3 = getModesByTier(3);
+		expect(t3.length).toBe(2);
+		expect(t3.map(m => m.id).sort()).toEqual(['lydian', 'phrygian']);
+	});
+
+	it('tier 4 has Locrian', () => {
+		const t4 = getModesByTier(4);
+		expect(t4.length).toBe(1);
+		expect(t4[0].id).toBe('locrian');
 	});
 
 	it('all modes have category "mode"', () => {
@@ -34,6 +57,20 @@ describe('MODES', () => {
 				expect(mode.intervals).toContain(c);
 			}
 		}
+	});
+
+	it('ionian has major scale intervals', () => {
+		const ion = getModeById('ionian');
+		expect(ion).toBeDefined();
+		expect(ion!.intervals).toEqual([0, 2, 4, 5, 7, 9, 11, 12]);
+		expect(ion!.degree).toBe(1);
+	});
+
+	it('aeolian has natural minor intervals', () => {
+		const aeo = getModeById('aeolian');
+		expect(aeo).toBeDefined();
+		expect(aeo!.intervals).toEqual([0, 2, 3, 5, 7, 8, 10, 12]);
+		expect(aeo!.degree).toBe(6);
 	});
 
 	it('dorian has correct intervals', () => {
@@ -61,25 +98,45 @@ describe('MODES', () => {
 		expect(lyd).toBeDefined();
 		expect(lyd!.intervals).toEqual([0, 2, 4, 6, 7, 9, 11, 12]);
 	});
+
+	it('locrian has correct intervals', () => {
+		const loc = getModeById('locrian');
+		expect(loc).toBeDefined();
+		expect(loc!.intervals).toEqual([0, 1, 3, 5, 6, 8, 10, 12]);
+		expect(loc!.degree).toBe(7);
+	});
 });
 
 describe('getModeById', () => {
 	it('returns mode for valid id', () => {
 		expect(getModeById('dorian')).toBeDefined();
+		expect(getModeById('ionian')).toBeDefined();
+		expect(getModeById('locrian')).toBeDefined();
 	});
 
 	it('returns undefined for invalid id', () => {
-		expect(getModeById('locrian')).toBeUndefined();
+		expect(getModeById('superlocrian')).toBeUndefined();
 	});
 });
 
 describe('getModesByTier', () => {
-	it('returns all modes for tier 4', () => {
-		expect(getModesByTier(4).length).toBe(4);
+	it('returns 2 modes for tier 1', () => {
+		expect(getModesByTier(1).length).toBe(2);
 	});
 
-	it('returns empty for other tiers', () => {
-		expect(getModesByTier(1).length).toBe(0);
-		expect(getModesByTier(3).length).toBe(0);
+	it('returns 2 modes for tier 2', () => {
+		expect(getModesByTier(2).length).toBe(2);
+	});
+
+	it('returns 2 modes for tier 3', () => {
+		expect(getModesByTier(3).length).toBe(2);
+	});
+
+	it('returns 1 mode for tier 4', () => {
+		expect(getModesByTier(4).length).toBe(1);
+	});
+
+	it('returns empty for non-existent tier', () => {
+		expect(getModesByTier(5).length).toBe(0);
 	});
 });


### PR DESCRIPTION
Expands modes from 4 (all locked) to 7 (all major scale modes) with tiered unlock:

- **T1 (unlocked):** Ionian (Major), Aeolian (Natural Minor)
- **T2:** Dorian, Mixolydian
- **T3:** Lydian, Phrygian
- **T4:** Locrian

State migration adds new modes for existing users. Default state unlocks T1.

Fixes #63. 292/292 tests pass, build clean.