### PR TITLE
fix: drone bleed — stop on navigation (Fixes #66)

### DIFF
--- a/src/routes/quiz/modes/+page.svelte
+++ b/src/routes/quiz/modes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
-	import { goto } from '$app/navigation';
+	import { goto, beforeNavigate } from '$app/navigation';
 	import { base } from '$app/paths';
 	import { loadState, saveState, checkTierUnlock } from '$lib/state';
 	import { generateModeQuestion } from '$lib/engine';
@@ -167,6 +167,12 @@
 	onDestroy(() => {
 		stopDrone();
 		if (rafId) cancelAnimationFrame(rafId);
+		noteTimeouts.forEach(clearTimeout);
+	});
+
+	// Ensure drone stops on client-side navigation (onDestroy alone isn't reliable in SvelteKit)
+	beforeNavigate(() => {
+		stopDrone();
 		noteTimeouts.forEach(clearTimeout);
 	});
 


### PR DESCRIPTION
Fixes #66

**Problem:** Modes quiz drone continues playing when navigating to other pages (intervals/chords/scales). Corrupts entire audio experience.

**Root cause:** `onDestroy` alone isn't reliable for cleanup during SvelteKit client-side navigation. The component may not be destroyed immediately during page transitions.

**Fix:** Added `beforeNavigate()` from `$app/navigation` to the modes quiz page. Stops drone and clears note timeouts on any navigation event. Belt-and-suspenders with `onDestroy`.

1 file changed, 7 insertions. 282/282 tests pass, build clean.