### PR TITLE
fix: version tag — dash separator + tap to copy (Fixes #71)

### DIFF
--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -3,7 +3,7 @@ export const APP_VERSION = '3.6';
 // Vite `define` injects this at build time — declared to satisfy TypeScript
 declare const __BUILD_HASH__: string;
 const buildHash = typeof __BUILD_HASH__ !== 'undefined' ? __BUILD_HASH__ : '';
-export const VERSION_STRING = buildHash ? `v${APP_VERSION}+${buildHash}` : `v${APP_VERSION}`;
+export const VERSION_STRING = buildHash ? `v${APP_VERSION}-${buildHash}` : `v${APP_VERSION}`;
 
 export interface ReleaseNote {
 	version: string;

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -8,6 +8,7 @@
 	import { APP_VERSION, VERSION_STRING, RELEASE_NOTES } from '$lib/version';
 
 	let showReleaseNotes = $state(false);
+	let versionCopied = $state(false);
 
 	let state: UserState | null = $state(null);
 
@@ -360,10 +361,19 @@
 
 		<div class="section version-section">
 			<label class="field-label">ABOUT</label>
-			<button class="version-btn" onclick={() => showReleaseNotes = !showReleaseNotes}>
-				<span class="version-label">{VERSION_STRING}</span>
-				<span class="version-toggle" class:open={showReleaseNotes}>{showReleaseNotes ? '^' : '>'}</span>
-			</button>
+			<div class="version-row">
+				<button class="version-copy" onclick={(e) => {
+					e.stopPropagation();
+					navigator.clipboard.writeText(VERSION_STRING);
+					versionCopied = true;
+					setTimeout(() => { versionCopied = false; }, 1500);
+				}}>
+					<span class="version-label">{versionCopied ? 'COPIED' : VERSION_STRING}</span>
+				</button>
+				<button class="version-btn" onclick={() => showReleaseNotes = !showReleaseNotes}>
+					<span class="version-toggle" class:open={showReleaseNotes}>{showReleaseNotes ? '^' : '>'}</span>
+				</button>
+			</div>
 
 			{#if showReleaseNotes}
 				<div class="release-notes">
@@ -604,9 +614,24 @@
 
 	/* Version + Release Notes */
 	.version-section { margin-top: 1rem; }
+	.version-row {
+		display: flex; gap: 0;
+	}
+	.version-copy {
+		flex: 1;
+		display: flex; align-items: center;
+		padding: 0.6rem 0.85rem;
+		background: var(--surface); border: 1px solid var(--border);
+		border-right: none;
+		color: var(--text-secondary); font-size: 0.45rem;
+		font-family: var(--mono); letter-spacing: 0.08em;
+		cursor: pointer;
+		transition: color 0.15s;
+	}
+	.version-copy:active { color: var(--accent); }
 	.version-btn {
-		display: flex; align-items: center; justify-content: space-between;
-		width: 100%; padding: 0.6rem 0.85rem;
+		display: flex; align-items: center; justify-content: center;
+		padding: 0.6rem 0.85rem;
 		background: var(--surface); border: 1px solid var(--border);
 		color: var(--text-secondary); font-size: 0.45rem;
 		font-family: var(--mono); letter-spacing: 0.08em;


### PR DESCRIPTION
Fixes #71

1. **Dash separator**: `v3.6+hash` → `v3.6-hash`
2. **Tap to copy**: Version label in Settings copies to clipboard on tap
3. **Visual feedback**: Shows 'COPIED' for 1.5s
4. **Layout**: Expand toggle separated from copy target (two buttons in a row)

292/292 tests, build clean.