### PR TITLE
fix: show answer cards immediately — no 600ms delay (Fixes #61)

### DIFF
--- a/src/routes/quiz/+page.svelte
+++ b/src/routes/quiz/+page.svelte
@@ -602,7 +602,7 @@
 			</button>
 		</VizQuizLayout>
 
-		<div class="answer-area" class:hidden={!hasPlayed && !needsTap}>
+		<div class="answer-area" class:hidden={!question}>
 			<AnswerGrid
 				choices={needsTap ? question.choices.map(c => ({ ...c, label: 'NA', name: 'UNAVAILABLE' })) : question.choices}
 				onselect={selectAnswer}

--- a/src/routes/quiz/chords/+page.svelte
+++ b/src/routes/quiz/chords/+page.svelte
@@ -563,7 +563,7 @@
 			</button>
 		</VizQuizLayout>
 
-		<div class="answer-area" class:hidden={!hasPlayed && !needsTap}>
+		<div class="answer-area" class:hidden={!question}>
 			<AnswerGrid
 				choices={needsTap ? question.choices.map(c => ({ ...c, label: 'NA', name: 'UNAVAILABLE' })) : question.choices}
 				onselect={selectAnswer}

--- a/src/routes/quiz/modes/+page.svelte
+++ b/src/routes/quiz/modes/+page.svelte
@@ -593,7 +593,7 @@
 			</button>
 		</VizQuizLayout>
 
-		<div class="answer-area" class:hidden={!hasPlayed && !needsTap}>
+		<div class="answer-area" class:hidden={!question}>
 			<AnswerGrid
 				choices={needsTap ? question.choices.map(c => ({ ...c, label: 'NA', name: 'UNAVAILABLE' })) : question.choices.map(c => ({ id: c.id, name: c.name, label: c.label }))}
 				onselect={selectAnswer}

--- a/src/routes/quiz/scales/+page.svelte
+++ b/src/routes/quiz/scales/+page.svelte
@@ -523,7 +523,7 @@
 			</button>
 		</VizQuizLayout>
 
-		<div class="answer-area" class:hidden={!hasPlayed && !needsTap}>
+		<div class="answer-area" class:hidden={!question}>
 			<AnswerGrid
 				choices={needsTap ? question.choices.map(c => ({ ...c, label: 'NA', name: 'UNAVAILABLE' })) : question.choices}
 				onselect={selectAnswer}


### PR DESCRIPTION
Fixes #61

**Root cause:** Answer area was gated by `!hasPlayed && !needsTap`. The 600ms glitch animation delay before `play()` meant answers stayed hidden for 600ms+ after the question loaded.

**Fix:** Changed visibility gate from `!hasPlayed && !needsTap` to `!question`. Answers now appear as soon as the question exists (~16ms), while still disabled until audio plays.

**UX:** User sees answer options immediately during the glitch transition. Cards are greyed/disabled until audio plays. No more delay.

4 files, 4 one-line changes. 292/292 tests, build clean.