### PR TITLE
fix: modes polish — drone bleed, toggle, mode text (Fixes #65 #66 #67)

### DIFF
--- a/src/routes/quiz/modes/+page.svelte
+++ b/src/routes/quiz/modes/+page.svelte
@@ -143,12 +143,18 @@
 
 		// Re-check audio on background resume (iOS suspends AudioContext)
 		const onVisible = () => {
-			if (document.visibilityState === 'visible' && !isAudioReady()) {
+			if (document.visibilityState === 'hidden') {
+				// Stop drone immediately when app goes to background
+				stopDrone();
+				drone = null;
+				isPlaying = false;
+				playingNotes = [];
+				noteTimeouts.forEach(clearTimeout);
+				noteTimeouts = [];
+			} else if (document.visibilityState === 'visible' && !isAudioReady()) {
 				audioUnlocked = false;
 				needsTap = true;
 				stopAudio();
-				stopDrone();
-				drone = null;
 				isPlaying = false;
 				playingNotes = [];
 			}
@@ -330,9 +336,8 @@
 	}
 
 	function toggleDroneMute() {
-		if (!drone) return;
 		droneMuted = !droneMuted;
-		drone.setMuted(droneMuted);
+		if (drone) drone.setMuted(droneMuted);
 	}
 
 	function selectAnswer(choice: { id: string; name: string }) {
@@ -554,10 +559,9 @@
 		</div>
 		<div class="top-controls">
 			<button class="close exit" onclick={endEarly}>EXIT</button>
-			<span class="mode-icon">MODE</span>
 			<div class="top-right">
 				<button class="drone-toggle" class:active={!droneMuted} onclick={toggleDroneMute}>
-					{droneMuted ? 'DRN' : 'DRN'}
+					{droneMuted ? 'DRN ✕' : 'DRN ✓'}
 				</button>
 				<span class="counter">{String(questionNum).padStart(2, '0')}/{String(totalQuestions).padStart(2, '0')}</span>
 			</div>


### PR DESCRIPTION
Fixes #65, fixes #66, fixes #67

**3 modes quiz fixes in 1 PR:**

**#66 (P0 drone bleed on background):** Added `visibilitychange: 'hidden'` handler that immediately stops drone when app goes to background. The previous `beforeNavigate` fix only caught SvelteKit navigation — iOS backgrounding bypassed it entirely. Now drone + note timeouts are killed on background.

**#65 (P1 drone toggle):** Removed `if (!drone) return` guard from `toggleDroneMute()`. Now toggles `droneMuted` state even when no drone is active — next drone will start muted. Button shows `DRN ✓/✕` for clear state.

**#67 (P2 mode text):** Removed redundant `MODE` text span below progress bar.

1 file, +11/-7. 292/292 tests, build clean.