### PR TITLE
fix: drone toggle — clear visual state (Fixes #65)

### DIFF
--- a/src/routes/quiz/modes/+page.svelte
+++ b/src/routes/quiz/modes/+page.svelte
@@ -562,8 +562,8 @@
 		<div class="top-controls">
 			<button class="close exit" onclick={endEarly}>EXIT</button>
 			<div class="top-right">
-				<button class="drone-toggle" class:active={!droneMuted} onclick={toggleDroneMute}>
-					{droneMuted ? 'DRN' : 'DRN'}
+				<button class="drone-toggle" class:active={!droneMuted} class:muted={droneMuted} onclick={toggleDroneMute}>
+					DRN
 				</button>
 				<span class="counter">{String(questionNum).padStart(2, '0')}/{String(totalQuestions).padStart(2, '0')}</span>
 			</div>
@@ -730,6 +730,11 @@
 	.drone-toggle.active {
 		color: var(--accent);
 		border-color: var(--accent);
+	}
+	.drone-toggle.muted {
+		color: var(--hot);
+		border-color: var(--hot);
+		opacity: 0.5;
 	}
 	.close {
 		font-size: 0.4rem;


### PR DESCRIPTION
Fixes #65

Drone toggle 'DRN' — text-only per Mike's request. State shown by color:
- **ON**: green (accent) border + text
- **OFF**: red (hot) border + text, 50% opacity

Toggle works when idle — sets `droneMuted` flag for next playback.

⚠️ Requires Mike's device verification before merge (audio rule).

1 file. 292/292 tests, build clean.