### PR TITLE
fix: wire ?onboard=1 to enable learn cards (Fixes #87)

### DIFF
--- a/src/lib/adaptive.ts
+++ b/src/lib/adaptive.ts
@@ -50,6 +50,7 @@ export interface SessionConfig {
 	length: number;
 	allowedKinds: ContentKind[];
 	mixStrategy: 'adaptive' | 'focused';
+	onboardMode?: boolean;
 }
 
 export type SessionPhase = 'learn' | 'warmup' | 'focus' | 'review';
@@ -318,10 +319,12 @@ export function needsLearnCard(
 	itemId: string,
 	stats: Record<string, ContentStats>,
 	devMode?: boolean,
+	onboardMode?: boolean,
 ): boolean {
-	// Disabled — learn cards need redesign before re-enabling.
-	// See DESIGN-ONBOARDING.md for the planned approach.
-	return false;
+	// Learn cards disabled by default — re-enabled only via ?onboard=1 query param
+	if (!onboardMode) return false;
+	const s = stats[itemId];
+	return !s || s.attempts === 0;
 }
 
 /**
@@ -391,7 +394,7 @@ export function planSession(
 	// --- Learn phase: items with attempts === 0 ---
 	let learnItems: PlannedQuestion[] = [];
 
-	if (!devMode) {
+	if (!devMode || config.onboardMode) {
 		// Cold start: use hard-coded intro sequence
 		if (isColdStart(stats)) {
 			const introItems = buildColdStartIntro();

--- a/src/routes/quiz/adaptive/+page.svelte
+++ b/src/routes/quiz/adaptive/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
+	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { base } from '$app/paths';
 	import { loadState, saveState, checkTierUnlock } from '$lib/state';
@@ -86,10 +87,13 @@
 		state = loadState();
 		totalQuestions = state.settings.sessionLength;
 
+		const onboardMode = page.url.searchParams.get('onboard') === '1';
+
 		const config: SessionConfig = {
 			length: totalQuestions,
 			allowedKinds: ['interval', 'chord', 'scale', 'mode'],
 			mixStrategy: 'adaptive',
+			onboardMode,
 		};
 
 		plan = planSession(state, config);


### PR DESCRIPTION
Fixes #87

Wires the `?onboard=1` query param to force-enable learn cards in the adaptive quiz:

- `needsLearnCard()` accepts `onboardMode` param
- `SessionConfig.onboardMode` passed to `planSession()`
- Adaptive quiz reads URL param on mount
- Settings 'ENTER ONBOARDING' → `/quiz/adaptive?onboard=1`
- No persistent state — override only for that page visit

292/292 tests, build clean.