### PR TITLE
fix: onboard page empty — pass onboardMode to needsLearnCard (Fixes #87)

### DIFF
--- a/src/lib/adaptive.ts
+++ b/src/lib/adaptive.ts
@@ -404,7 +404,7 @@ export function planSession(
 		} else {
 			// Normal: find new items sorted by tier (lowest first)
 			const newItems = eligible
-				.filter(item => needsLearnCard(item.id, stats))
+				.filter(item => needsLearnCard(item.id, stats, devMode, config.onboardMode))
 				.sort((a, b) => a.tier - b.tier)
 				.slice(0, MAX_LEARN_PER_SESSION);
 			learnItems = newItems.map(item => ({ item, phase: 'learn' as SessionPhase }));


### PR DESCRIPTION
Fixes the empty onboarding page reported by Mike on v3.6-db526ec.

**Root cause:** `needsLearnCard()` in `planSession()`'s Normal path was called without `onboardMode` param — always returned false (disabled), so no learn items were generated.

**Fix:** Pass `config.onboardMode` through to the filter call.

1 line changed. 292/292 tests, build clean.